### PR TITLE
Add Dockerfile for OCP to enable release CI process PR# 30687

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,0 +1,22 @@
+# Build the manager binary
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+COPY pkg/ pkg/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -mod=vendor -o manager main.go
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.12
+WORKDIR /
+COPY --from=builder /workspace/manager .
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Creating basic OCP dockerfile to enable openshift-ci bot functionality for this repo
and unblock [PR#30687](https://github.com/openshift/release/pull/30687)
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

