### PR TITLE
Fix variable in Makefile for ebpf-generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,8 +261,8 @@ prereqs: ## Check if prerequisites are met, and installing missing dependencies
 # protobuf definitions in the proto folder.
 # You might want to use the docker-generate target instead of this.
 .PHONY: ebpf-generate
-generate: export BPF_CLANG := $(CLANG)
-generate: export BPF_CFLAGS := $(CFLAGS)
+ebpf-generate: export BPF_CLANG := $(CLANG)
+ebpf-generate: export BPF_CFLAGS := $(CFLAGS)
 ebpf-generate: prereqs ## Generating BPF Go bindings
 	@echo "### Generating BPF Go bindings"
 	go generate ./pkg/...


### PR DESCRIPTION
BPF_CLANG and BPF_CLANGS should be set for ebpf-generate.
That way, the ebpf-generate target can be called by itself,
without the generate target.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/openshift/ingress-node-firewall/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
