### PR TITLE
Add Multicast DNS port 5353 to UDP's failsafe rules

### DIFF
--- a/pkg/failsaferules/failsaferules.go
+++ b/pkg/failsaferules/failsaferules.go
@@ -33,6 +33,10 @@ var udp = []TransportProtoFailSafeRule{
 		"DHCP",
 		68,
 	},
+	{
+		"mDNS",
+		5353,
+	},
 }
 
 func GetTCP() []TransportProtoFailSafeRule {


### PR DESCRIPTION
BPF was dropping mDNS UDP packets on port 5353
```
2022/08/01 17:29:29 ========= Drop Event ===========
2022/08/01 17:29:29     ruleId 0 action Drop len 81
2022/08/01 17:29:29     ipv4 src addr 172.18.0.1 dst addr 224.0.0.251
2022/08/01 17:29:29     udp srcPort 5353 dstPort 5353
```
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

