### PR TITLE
E2E test case to check for eBPF events generattion

### DIFF
--- a/test/consts/const.go
+++ b/test/consts/const.go
@@ -17,4 +17,6 @@ const (
 	DefaultOperatorNameSpace = "ingress-node-firewall-system"
 	// IngressNodeFirewallConfigCRFile configuration yaml file
 	IngressNodeFirewallConfigCRFile = "ingress-node-firewall-config.yaml"
+	// IngressNodeFirewallEventsLogFile eBPF events logs file
+	IngressNodeFirewallEventsLogFile = "/tmp/ingress_node_firewall_events.log"
 )


### PR DESCRIPTION
```
Ingress Node Firewall IngressNodeFirewall deploy 
  should run Ingress node firewall apply rules and check the actions
  /home/mmahmoud/go/src/ingress-node-firewall/test/e2e/functional/tests/e2e.go:92
STEP: get nodes IP addresses with matching labels and ping their IPs
STEP: creating ingress node firewall rules
STEP: checking Ingress node firewall rules resource is created
STEP: checking ingress node firewall nodeState resource is created
STEP: checking Ingress node firewall rules deny ping packets
STEP: checking ingress node firewall events are generated
STEP: checking Ingress node firewall nodeState resource is deleted
STEP: checking Ingress node firewall rules resource is deleted

• [SLOW TEST:32.318 seconds]
Ingress Node Firewall
/home/mmahmoud/go/src/ingress-node-firewall/test/e2e/functional/tests/e2e.go:36
  IngressNodeFirewall deploy
  /home/mmahmoud/go/src/ingress-node-firewall/test/e2e/functional/tests/e2e.go:37
    should run Ingress node firewall apply rules and check the actions
    /home/mmahmoud/go/src/ingress-node-firewall/test/e2e/functional/tests/e2e.go:92
------------------------------
```
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

