### PR TITLE
Add OCP dockerfile to build DaemonSet.

### DIFF
--- a/Dockerfile.daemon.openshift
+++ b/Dockerfile.daemon.openshift
@@ -1,0 +1,9 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+
+WORKDIR /go/src/github.com/openshift/ingress-node-firewall
+COPY . .
+RUN ./hack/build-daemon.sh
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.12
+COPY --from=builder /go/src/github.com/openshift/ingress-node-firewall/bin/daemon /usr/bin/
+CMD ["/usr/bin/daemon"]

--- a/hack/build-daemon.sh
+++ b/hack/build-daemon.sh
@@ -6,7 +6,8 @@ REPO=github.com/openshift/ingress-node-firewall
 WHAT=daemon
 BIN_PATH=bin
 
-GOFLAGS=${GOFLAGS:-}
+GOFLAGS=${GOFLAGS:-"-mod=vendor"}
+
 LDFLAGS=${LDFLAGS:-}
 
 # Set cross compilation flags and version override.


### PR DESCRIPTION
Need to have dockefile for OCP to build Daemonset image by the release team
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
