### PR TITLE
Panic right away if kubeconfig cannot be found

### DIFF
--- a/test/e2e/client/client.go
+++ b/test/e2e/client/client.go
@@ -55,7 +55,7 @@ func New(kubeconfig string) *ClientSet {
 	}
 	if err != nil {
 		glog.Infof("Failed to init kubernetes client, please check the $KUBECONFIG environment variable")
-		return nil
+		panic(err)
 	}
 
 	clientSet := &ClientSet{}


### PR DESCRIPTION
Instead of failing later down the road with a nil pointer exception,
panic early instead.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

Would this make sense?

The result will be:
~~~
[akaris@linux ingress-node-firewall (sdn-3315)]$ make test-e2e
/home/akaris/development/ingress-node-firewall/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
==== Generating DaemonSet manifest
hack/generate-daemon-manifest.sh
/home/akaris/development/ingress-node-firewall/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
rm -rf /tmp/test_validation_logs/
mkdir -p /tmp/test_validation_logs/
go test --tags=validationtests -v ./test/e2e/validation -ginkgo.v -junit /tmp/test_validation_logs/ -report /tmp/test_validation_logs/
ERROR: logging before flag.Parse: I0808 20:35:29.880587  141919 client.go:57] Failed to init kubernetes client, please check the $KUBECONFIG environment variable
panic: stat hack/kubeconfig: no such file or directory

goroutine 1 [running]:
github.com/openshift/ingress-node-firewall/test/e2e/client.New({0x0?, 0x21957c0?})
	/home/akaris/development/ingress-node-firewall/test/e2e/client/client.go:58 +0x416
github.com/openshift/ingress-node-firewall/test/e2e/client.init.0()
	/home/akaris/development/ingress-node-firewall/test/e2e/client/client.go:26 +0x1d
FAIL	github.com/openshift/ingress-node-firewall/test/e2e/validation	0.017s
FAIL
make: *** [Makefile:125: test-validation] Error 1
~~~

Instead of getting a nil pointer exception:
~~~
akaris@linux ingress-node-firewall (sdn-3315)]$ make test-e2e
/home/akaris/development/ingress-node-firewall/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
==== Generating DaemonSet manifest
hack/generate-daemon-manifest.sh
/home/akaris/development/ingress-node-firewall/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
rm -rf /tmp/test_validation_logs/
mkdir -p /tmp/test_validation_logs/
go test --tags=validationtests -v ./test/e2e/validation -ginkgo.v -junit /tmp/test_validation_logs/ -report /tmp/test_validation_logs/
ERROR: logging before flag.Parse: I0808 20:37:15.179971  144695 client.go:57] Failed to init kubernetes client, please check the $KUBECONFIG environment variable
=== RUN   TestValidation
Running Suite: Ingress Node Firewall Operator Validation Suite
==============================================================
Random Seed: 1659983835
Will run 4 of 4 specs

IngressNodeFirewall IngressNodeFirewall 
  should have the IngressNodeFirewall Operator deployment in running state
  /home/akaris/development/ingress-node-firewall/test/e2e/validation/tests/validation.go:30

•! Panic [0.001 seconds]
IngressNodeFirewall
/home/akaris/development/ingress-node-firewall/test/e2e/validation/tests/validation.go:28
  IngressNodeFirewall
  /home/akaris/development/ingress-node-firewall/test/e2e/validation/tests/validation.go:29
    should have the IngressNodeFirewall Operator deployment in running state [It]
    /home/akaris/development/ingress-node-firewall/test/e2e/validation/tests/validation.go:30

    Test Panicked
    runtime error: invalid memory address or nil pointer dereference
    /usr/local/go/src/runtime/panic.go:220

    Full Stack Trace
    github.com/openshift/ingress-node-firewall/test/e2e/validation/tests.glob..func1.1.1.1()
    	/home/akaris/development/ingress-node-firewall/test/e2e/validation/tests/validation.go:32 +0x1f
    reflect.Value.call({0x139e700?, 0x16a5668?, 0x0?}, {0x15cd423, 0x4}, {0xc0000eea70, 0x0, 0x1?})
    	/usr/local/go/src/reflect/value.go:556 +0x845
    reflect.Value.Call({0x139e700?, 0x16a5668?, 0x4570ad?}, {0xc0000eea70, 0x0, 0x0})
    	/usr/local/go/src/reflect/value.go:339 +0xbf
    github.com/onsi/gomega/internal.NewAsyncAssertion.func1()
    	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/gomega/internal/async_assertion.go:48 +0xb1
    github.com/onsi/gomega/internal.(*AsyncAssertion).pollActual(0x17f8720?)
    	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/gomega/internal/async_assertion.go:132 +0x39
    github.com/onsi/gomega/internal.(*AsyncAssertion).match(0xc0000ae0f0, {0x17e5d10, 0x22f0ab8}, 0x1, {0x0, 0x0, 0x0})
    	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/gomega/internal/async_assertion.go:162 +0xa5
    github.com/onsi/gomega/internal.(*AsyncAssertion).Should(0xc0000ae0f0, {0x17e5d10, 0x22f0ab8}, {0x0, 0x0, 0x0})
    	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/gomega/internal/async_assertion.go:107 +0x6b
    github.com/openshift/ingress-node-firewall/test/e2e/validation/tests.glob..func1.1.1()
    	/home/akaris/development/ingress-node-firewall/test/e2e/validation/tests/validation.go:37 +0x98
    github.com/openshift/ingress-node-firewall/test/e2e/validation.TestValidation(0x0?)
    	/home/akaris/development/ingress-node-firewall/test/e2e/validation/validation_test.go:51 +0x2e5
    testing.tRunner(0xc000603380, 0x16a5660)
    	/usr/local/go/src/testing/testing.go:1439 +0x102
    created by testing.(*T).Run
    	/usr/local/go/src/testing/testing.go:1486 +0x35f
------------------------------
--- FAIL: TestValidation (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x12bd0f8]

goroutine 10 [running]:
testing.tRunner.func1.2({0x14278e0, 0x22850e0})
	/usr/local/go/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1392 +0x39f
panic({0x14278e0, 0x22850e0})
	/usr/local/go/src/runtime/panic.go:838 +0x207
github.com/openshift/ingress-node-firewall/test/e2e/k8sreporter.(*KubernetesReporter).logNodes(0xc00044f660, {0xc00002e5b0, 0x6e})
	/home/akaris/development/ingress-node-firewall/test/e2e/k8sreporter/reporter.go:116 +0xf8
github.com/openshift/ingress-node-firewall/test/e2e/k8sreporter.(*KubernetesReporter).Dump(0xc00044f660, {0xc00002e5b0, 0x6e})
	/home/akaris/development/ingress-node-firewall/test/e2e/k8sreporter/reporter.go:72 +0xdd
github.com/openshift/ingress-node-firewall/test/e2e/k8sreporter.(*KubernetesReporter).SpecDidComplete(0xc00044f660, 0xc00071e100)
	/home/akaris/development/ingress-node-firewall/test/e2e/k8sreporter/reporter.go:61 +0x239
github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).reportSpecDidComplete(0xc0002a8dc0, 0xc00071e100, 0x1)
	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:307 +0xae
github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpec(0xc0002a8dc0, 0xc0003f4000)
	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:202 +0x146
github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpecs(0xc0002a8dc0)
	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:170 +0x1a5
github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run(0xc0002a8dc0)
	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:66 +0xc5
github.com/onsi/ginkgo/internal/suite.(*Suite).Run(0xc000184620, {0x7f6aca776600, 0xc000603380}, {0x1606723, 0x2f}, {0xc000315dd0, 0x3, 0x3}, {0x17f20b8, 0xc0005b0fc0}, ...)
	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:79 +0x4d2
github.com/onsi/ginkgo.runSpecsWithCustomReporters({0x17df2a0?, 0xc000603380}, {0x1606723, 0x2f}, {0xc0005b18c0, 0x3, 0x15e66ac?})
	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:245 +0x189
github.com/onsi/ginkgo.RunSpecsWithDefaultAndCustomReporters({0x17df2a0, 0xc000603380}, {0x1606723, 0x2f}, {0xc00044f6a0, 0x2, 0x2})
	/home/akaris/development/ingress-node-firewall/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:228 +0x1b6
github.com/openshift/ingress-node-firewall/test/e2e/validation.TestValidation(0x0?)
	/home/akaris/development/ingress-node-firewall/test/e2e/validation/validation_test.go:51 +0x2e5
testing.tRunner(0xc000603380, 0x16a5660)
	/usr/local/go/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1486 +0x35f
FAIL	github.com/openshift/ingress-node-firewall/test/e2e/validation	0.023s
FAIL
make: *** [Makefile:125: test-validation] Error 1
~~~
