### PR TITLE
change how we do envtest target and linit script to work from ci repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Temporary direcyories and files
 bin/*
-
+testbin/*
 kubeconfig
+

--- a/Makefile
+++ b/Makefile
@@ -238,10 +238,15 @@ controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessar
 $(CONTROLLER_GEN): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
+ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
+
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN)
+	mkdir -p ${ENVTEST_ASSETS_DIR}
+	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR);
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -4,5 +4,11 @@
 
 VERSION="v1.45.2"
 
-docker run --rm -v $(pwd):/app:z -w /app -e GO111MODULE=on golangci/golangci-lint:${VERSION} \
+if [[ $(which podman) && $(podman --version) ]]; then
+  command=podman
+else
+  command=docker
+fi
+
+${command} run --rm -v $(pwd):/app:z -w /app -e GO111MODULE=on golangci/golangci-lint:${VERSION} \
 	golangci-lint run --verbose --print-resources-usage --timeout=15m0s


### PR DESCRIPTION
It is causing issues when run unit-test from
release CI we get the following error
GOBIN=/go/src/github.com/openshift/ingress-node-firewall/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0
25
go: sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0: cannot query module due to -mod=vendor
26
make: *** [/go/src/github.com/openshift/ingress-node-firewall/bin/controller-gen] Error 1

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

