### PR TITLE
Fix initial e2e run issue #99

### DIFF
--- a/controllers/ingressnodefirewall_controller.go
+++ b/controllers/ingressnodefirewall_controller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 
 	infv1alpha1 "github.com/openshift/ingress-node-firewall/api/v1alpha1"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -211,7 +210,7 @@ func (r *IngressNodeFirewallReconciler) triggerReconciliation(object client.Obje
 		return []reconcile.Request{}
 	}
 
-	// We do not need to reconcile anything if there are no items of type IngressNodeFirwall.
+	// We do not need to reconcile anything if there are no items of type IngressNodeFirewall.
 	if len(ingressNodeFirewallList.Items) == 0 {
 		return []reconcile.Request{}
 	}
@@ -324,17 +323,6 @@ func (r *IngressNodeFirewallReconciler) buildNodeStates(
 				continue withNextNode
 			}
 			for _, iface := range firewallObj.Spec.Interfaces {
-				// Verify if an invalid interface name was specified.
-				// On error, report the error in the status field and continue with the next node.
-				if !isLegalInterfaceName(iface) {
-					state.Status = infv1alpha1.IngressNodeFirewallNodeStateStatus{
-						SyncStatus:       infv1alpha1.SyncError,
-						SyncErrorMessage: fmt.Sprintf("Invalid interface name %s", iface),
-					}
-					// Write back the state to the map and then continue with the next node.
-					nodeStates[node.Name] = state
-					continue withNextNode
-				}
 				// Create the rules for the node spec if they do not yet exist for this interface.
 				if _, ok := state.Spec.InterfaceIngressRules[iface]; !ok {
 					state.Spec.InterfaceIngressRules[iface] = []infv1alpha1.IngressNodeFirewallRules{}
@@ -359,13 +347,6 @@ func (r *IngressNodeFirewallReconciler) buildNodeStates(
 	}
 
 	return nodeStates, nil
-}
-
-func isLegalInterfaceName(iface string) bool {
-	if iface == "" {
-		return false
-	}
-	return true
 }
 
 // mergeRuleSet merges 2 rulesets of type []infv1alpha1.IngressNodeFirewallRules.

--- a/controllers/ingressnodefirewall_controller_test.go
+++ b/controllers/ingressnodefirewall_controller_test.go
@@ -18,13 +18,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	timeout  = time.Second * 10
+	interval = time.Millisecond * 250
+)
+
 var _ = Describe("IngressNodeFirewall controller", func() {
-
-	const (
-		timeout  = time.Second * 10
-		interval = time.Millisecond * 250
-	)
-
 	ctx := context.Background()
 
 	ingressNodeFirewallName := "firewall1"

--- a/pkg/ebpfsyncer/ebpfsyncer_test.go
+++ b/pkg/ebpfsyncer/ebpfsyncer_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	infv1alpha1 "github.com/openshift/ingress-node-firewall/api/v1alpha1"
+
 	"github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -37,7 +38,9 @@ func TestSyncInterfaceIngressRulesConnectDenyRule(t *testing.T) {
 
 	defer afterEach(t)
 	beforeEach(t)
-
+	isValidInterfaceNameAndState = func(ifName string) bool {
+		return true
+	}
 	rules := map[string][]infv1alpha1.IngressNodeFirewallRules{
 		fmt.Sprintf("%s0", interfacePrefix): {
 			{
@@ -96,7 +99,9 @@ func TestSyncInterfaceIngressRulesConnectAllowRule(t *testing.T) {
 
 	defer afterEach(t)
 	beforeEach(t)
-
+	isValidInterfaceNameAndState = func(ifName string) bool {
+		return true
+	}
 	rules := map[string][]infv1alpha1.IngressNodeFirewallRules{
 		fmt.Sprintf("%s0", interfacePrefix): {
 			{
@@ -154,7 +159,9 @@ func TestSyncInterfaceIngressRulesConnectAllowRule(t *testing.T) {
 func TestSyncInterfaceIngressRulesAttachAndDetachSingleInterface(t *testing.T) {
 	defer afterEach(t)
 	beforeEach(t)
-
+	isValidInterfaceNameAndState = func(ifName string) bool {
+		return true
+	}
 	rules := map[string][]infv1alpha1.IngressNodeFirewallRules{
 		fmt.Sprintf("%s0", interfacePrefix): {
 			{
@@ -220,7 +227,9 @@ func TestSyncInterfaceIngressRulesAttachAndDetachSingleInterface(t *testing.T) {
 func TestSyncInterfaceIngressRulesAttachAndDetach(t *testing.T) {
 	defer afterEach(t)
 	beforeEach(t)
-
+	isValidInterfaceNameAndState = func(ifName string) bool {
+		return true
+	}
 	rules := map[string][]infv1alpha1.IngressNodeFirewallRules{
 		fmt.Sprintf("%s0", interfacePrefix): {
 			{
@@ -304,7 +313,9 @@ func TestSyncInterfaceIngressRulesAttachAndDetach(t *testing.T) {
 func TestResyncInterfaceIngressRulesSingleInterface(t *testing.T) {
 	defer afterEach(t)
 	beforeEach(t)
-
+	isValidInterfaceNameAndState = func(ifName string) bool {
+		return true
+	}
 	rules := map[string][]infv1alpha1.IngressNodeFirewallRules{
 		fmt.Sprintf("%s0", interfacePrefix): {
 			{
@@ -359,7 +370,9 @@ func TestResyncInterfaceIngressRulesSingleInterface(t *testing.T) {
 func TestResyncInterfaceIngressRules(t *testing.T) {
 	defer afterEach(t)
 	beforeEach(t)
-
+	isValidInterfaceNameAndState = func(ifName string) bool {
+		return true
+	}
 	rules := map[string][]infv1alpha1.IngressNodeFirewallRules{
 		fmt.Sprintf("%s0", interfacePrefix): {
 			{

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -145,6 +145,34 @@ var _ = BeforeSuite(func() {
 
 }, 60)
 
+var _ = Describe("Interfaces", func() {
+	var inf *ingressnodefwv1alpha1.IngressNodeFirewall
+
+	BeforeEach(func() {
+		inf = getIngressNodeFirewall("interfaces-validation")
+	})
+
+	Context("ingress node firewall interfaces validation", func() {
+		It("interfaces config with valid interfaces name", func() {
+			configInterfaces(inf, []string{"eth0", "eth1"})
+			Expect(createIngressNodeFirewall(inf)).To(Succeed())
+			Expect(deleteIngressNodeFirewall(inf)).To(Succeed())
+		})
+		It("interfaces config with empty strings", func() {
+			configInterfaces(inf, []string{""})
+			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
+		})
+		It("interfaces config with too long interface name", func() {
+			configInterfaces(inf, []string{"abcd123459$%&ABDC44555555555"})
+			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
+		})
+		It("interfaces config with interface name starts with number", func() {
+			configInterfaces(inf, []string{"0th"})
+			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
+		})
+	})
+})
+
 var _ = Describe("Rules", func() {
 	Context("protocol is ICMPv4", func() {
 		var inf *ingressnodefwv1alpha1.IngressNodeFirewall
@@ -617,5 +645,11 @@ func getICMPv6Rule(order uint32, protocol ingressnodefwv1alpha1.IngressNodeFirew
 			},
 		},
 		Action: action,
+	}
+}
+
+func configInterfaces(inf *ingressnodefwv1alpha1.IngressNodeFirewall, intfs []string) {
+	for _, intf := range intfs {
+		inf.Spec.Interfaces = append(inf.Spec.Interfaces, intf)
 	}
 }


### PR DESCRIPTION
Fix #99 
- allow some waiting time for rules delete to complete.
- remove webhook test cases that are now not allowed by the APIs.

here is what the API verify for us:
- for order 0 we will get this error
```
The IngressNodeFirewall "ingressnodefirewall-demo2" is invalid: spec.ingress[0].rules[0].order: Invalid value: 0: spec.ingress[0].rules[0].order in body should be greater than or equal to 1
```
- for mixed protocol case we will get
```
* spec.ingress[0][rules][0]: Invalid value: "ingressnodefirewall-demo2": must be a valid TCP rule: no port defined
* spec.ingress[0][rules][1]: Invalid value: "ingressnodefirewall-demo2": must be a valid ICMP(V6) rule: no ICMP rules defined. Define icmpType/icmpCode
```
here is fresh e2e run after cluster is created after adding the wait to make sure rules are deleted
```
Ran 10 of 10 Specs in 198.667 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped
```
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
