### PR TITLE
fix one of the unit-test race condition issues

### DIFF
--- a/controllers/ingressnodefirewall_controller_rules_test.go
+++ b/controllers/ingressnodefirewall_controller_rules_test.go
@@ -406,7 +406,7 @@ var _ = Describe("IngressNodeFirewall controller rules", func() {
 									ProtocolConfig: infv1alpha1.IngressNodeProtocolConfig{
 										Protocol: infv1alpha1.ProtocolTypeTCP,
 										TCP: &infv1alpha1.IngressNodeFirewallProtoRule{
-											Ports: intstr.FromInt(80),
+											Ports: intstr.FromInt(88),
 										},
 									},
 									Action: infv1alpha1.IngressNodeFirewallDeny,
@@ -438,7 +438,7 @@ var _ = Describe("IngressNodeFirewall controller rules", func() {
 									ProtocolConfig: infv1alpha1.IngressNodeProtocolConfig{
 										Protocol: infv1alpha1.ProtocolTypeTCP,
 										TCP: &infv1alpha1.IngressNodeFirewallProtoRule{
-											Ports: intstr.FromInt(80),
+											Ports: intstr.FromInt(88),
 										},
 									},
 									Action: infv1alpha1.IngressNodeFirewallDeny,

--- a/controllers/ingressnodefirewallconfig_controller_test.go
+++ b/controllers/ingressnodefirewallconfig_controller_test.go
@@ -13,17 +13,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Ingress nodefirewall config Controller", func() {
 	Context("syncIngressNodeFwConfig", func() {
-
-		AfterEach(func() {
-			err := cleanTestNamespace()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
 		It("Should create manifests with images and namespace overriden", func() {
 
 			config := &ingressnodefwv1alpha1.IngressNodeFirewallConfig{
@@ -123,12 +116,3 @@ var _ = Describe("Ingress nodefirewall config Controller", func() {
 		})
 	})
 })
-
-func cleanTestNamespace() error {
-	err := k8sClient.DeleteAllOf(context.Background(), &ingressnodefwv1alpha1.IngressNodeFirewallConfig{}, client.InNamespace(IngressNodeFwConfigTestNameSpace))
-	if err != nil {
-		return err
-	}
-	err = k8sClient.DeleteAllOf(context.Background(), &appsv1.DaemonSet{}, client.InNamespace(IngressNodeFwConfigTestNameSpace))
-	return err
-}


### PR DESCRIPTION
Fix one of the race conditions in #93 where fwconfig was removing the namespace while fwrules and nodestate are still running.

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
