### PR TITLE
hack/kind-cluster.sh: Enable local container registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ make bundle
 make create-kind-cluster
 export KUBECONFIG=$(pwd)/hack/kubeconfig
 ```
+
+Note: the `create-kind-cluster` script will also standup an additional
+local image registry, available at `localhost:5001`. You can push and
+pull images to/from this registry for a faster dev cycle.
+
 3. Install custom resource definitions
 ```sh
 make install
@@ -115,6 +120,12 @@ make install
 4. Build controller container image
 ```sh
 make docker-build IMG=<some-registry>/ingress-node-firewall-controller:tag
+```
+For a faster dev cycle consider using the local image registry
+available at `localhost:5001` when building and pushing images.
+For example, the previous build would specify:
+```sh
+make docker-build IMG=localhost:5001/ingress-node-firewall-controller:tag
 ```
 5. Load controller container image to KinD container(s)
 ```sh
@@ -155,6 +166,11 @@ make docker-build IMG=<some-registry>/ingress-node-firewall-controller:tag
 4. Push controller container image to an image registry
 ```sh
 make docker-push IMG=<some-registry>/ingress-node-firewall-controller:tag
+```
+If you're using the local container registry then the push would be:
+
+```sh
+make docker-push IMG=localhost:5001/ingress-node-firewall-controller:tag
 ```
 5. Build daemon container image
 ```sh


### PR DESCRIPTION
These changes enable a local container registry that the KIND cluster
can pull from. This allows builds of the controller and daemon images
to be pushed to the local registry and that is substantially faster
then pushing externally.

The additions were copied from: https://kind.sigs.k8s.io/docs/user/local-registry/.

Assume the following environment:

    set -a
    : "${IMAGE_ORG:=$USER}"
    : "${IMAGE_REGISTRY:=localhost:5001}"
    : "${DAEMON_IMG:=${IMAGE_REGISTRY}/${IMAGE_ORG}/ingress-node-firewall-daemon}"
    : "${DAEMONSET_IMAGE:=${IMAGE_REGISTRY}/${IMAGE_ORG}/ingress-node-firewall-daemon}"
    : "${DAEMONSET_NAMESPACE:=ingress-node-firewall-system}"
    : "${KUBECONFIG:=$PWD/hack/kubeconfig}"
    : "${IMG:=${IMAGE_REGISTRY}/${IMAGE_ORG}/ingress-node-firewall:latest}"
    : "${KUBE_RBAC_PROXY_IMAGE:=${IMAGE_REGISTRY}/openshift/origin-kube-rbac-proxy:latest}"
    : "${IMAGE_TAG_BASE:=${IMAGE_REGISTRY}/${IMAGE_ORG}/ingress-nodefw/ingress-node-firewall}"
    set +a

Then builds and pushes of the daemon and controller images can be done
quickly to the local registry.

    % make -n docker-build
    ...
    docker build -t localhost:5001/aim/ingress-node-firewall:latest .

    % make -n docker-push
    ...
    docker push localhost:5001/aim/ingress-node-firewall:latest

And ditto for the podman equivalents:

    % make -n podman-build-daemon
    ...
    podman build -t localhost:5001/aim/ingress-node-firewall-daemon -f Dockerfile.daemon .

    % make -n docker-push-daemon
    ...
    docker push quay.io/aim/ingress-node-firewall-daemon

The time to pull an image locally versus remotely can be
significant (at least for me):

    $ oc describe pod -n ingress-node-firewall-system ingress-node-firewall-controller-manager-795558b997-twz4t

    Events:
      Type     Reason       Age   From               Message
      ----     ------       ----  ----               -------
      Normal   Scheduled    26m   default-scheduler  Successfully assigned ingress-node-firewall-system/ingress-node-firewall-controller-manager-795558b997-twz4t to kind-control-plane
      Warning  FailedMount  26m   kubelet            MountVolume.SetUp failed for volume "cert" : secret "webhook-server-cert" not found
      Normal   Pulling      26m   kubelet            Pulling image "localhost:5001/aim/ingress-node-firewall:latest"
      Normal   Pulled       26m   kubelet            Successfully pulled image "localhost:5001/aim/ingress-node-firewall:latest" in 415.400926ms
      Normal   Created      26m   kubelet            Created container manager
      Normal   Started      26m   kubelet            Started container manager
      Normal   Pulling      26m   kubelet            Pulling image "quay.io/openshift/origin-kube-rbac-proxy:latest"
      Normal   Pulled       25m   kubelet            Successfully pulled image "quay.io/openshift/origin-kube-rbac-proxy:latest" in 54.975679768s
      Normal   Created      25m   kubelet            Created container kube-rbac-proxy
      Normal   Started      25m   kubelet            Started container kube-rbac-proxy

Signed-off-by: Andrew McDermott <amcdermo@redhat.com>
