### PR TITLE
 E2E: Remove hardcode KinD's CIDR range from e2e fw rules

### DIFF
--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -99,6 +99,9 @@ var _ = Describe("Ingress Node Firewall", func() {
 			err, _ = infwutils.RunPingTest(nodes.Items)
 			Expect(err).ToNot(HaveOccurred())
 
+			v4CIDR, v6CIDR, err := infwutils.GetRuleCIDR(nodes.Items)
+			Expect(err).ToNot(HaveOccurred())
+
 			By("creating ingress node firewall rules")
 			rules := &ingressnodefwv1alpha1.IngressNodeFirewall{
 				ObjectMeta: metav1.ObjectMeta{
@@ -110,7 +113,7 @@ var _ = Describe("Ingress Node Firewall", func() {
 					},
 					Ingress: []ingressnodefwv1alpha1.IngressNodeFirewallRules{
 						{
-							SourceCIDRs: []string{"172.16.0.0/12"},
+							SourceCIDRs: []string{v4CIDR},
 							FirewallProtocolRules: []ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule{
 								{
 									Order: 10,
@@ -135,7 +138,7 @@ var _ = Describe("Ingress Node Firewall", func() {
 							},
 						},
 						{
-							SourceCIDRs: []string{"fc00:f853:ccd:e793::0/64"},
+							SourceCIDRs: []string{v6CIDR},
 							FirewallProtocolRules: []ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule{
 								{
 									Order: 10,
@@ -292,6 +295,9 @@ var _ = Describe("Ingress Node Firewall", func() {
 			err, _ = infwutils.RunPingTest(nodes.Items)
 			Expect(err).ToNot(HaveOccurred())
 
+			v4CIDR, _, err := infwutils.GetRuleCIDR(nodes.Items)
+			Expect(err).ToNot(HaveOccurred())
+
 			rules := &ingressnodefwv1alpha1.IngressNodeFirewall{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "rules1",
@@ -302,7 +308,7 @@ var _ = Describe("Ingress Node Firewall", func() {
 					},
 					Ingress: []ingressnodefwv1alpha1.IngressNodeFirewallRules{
 						{
-							SourceCIDRs: []string{"172.0.0.0/8"},
+							SourceCIDRs: []string{v4CIDR},
 							FirewallProtocolRules: []ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule{
 								{
 									Order: 1,

--- a/test/e2e/ingress-node-firewall/ingress-node-firewall.go
+++ b/test/e2e/ingress-node-firewall/ingress-node-firewall.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"time"
@@ -103,6 +104,29 @@ func NodesIPs(nodes []v1.Node) []string {
 		}
 	}
 	return res
+}
+
+func GetRuleCIDR(nodes []v1.Node) (string, string, error) {
+	var v4CIDR, v6CIDR string
+	v4CIDRLen := 12
+	v6CIDRLen := 64
+	ips := NodesIPs(nodes)
+	for _, ip := range ips {
+		addr := net.ParseIP(ip)
+		if addr.To4() != nil {
+			v4Mask := net.CIDRMask(v4CIDRLen, 32)
+			v4CIDR = fmt.Sprintf("%s/%d", addr.Mask(v4Mask), v4CIDRLen)
+		} else if addr.To16() != nil {
+			v6Mask := net.CIDRMask(v6CIDRLen, 128)
+			v6CIDR = fmt.Sprintf("%s/%d", addr.Mask(v6Mask), v6CIDRLen)
+		} else {
+			return "", "", fmt.Errorf("invalid ip address family %s", ip)
+		}
+		if v4CIDR != "" && v6CIDR != "" {
+			break
+		}
+	}
+	return v4CIDR, v6CIDR, nil
 }
 
 func RunPingTest(nodes []v1.Node) (error, int) {


### PR DESCRIPTION
**- What this PR does and why is it needed**
we need to be able to run e2e test on any cluster not KinD cluster only


**- How to verify it**
- run `make test-e2e` on any cluster CIDR range should be calculated based on the nodes IPv4and IPv6 addresses.
- manual run of e2e passed on kind
```
JUnit report was created: /tmp/test_e2e_logs/e2e_junit.xml

Ran 10 of 10 Specs in 304.583 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped
```

**- Description for the changelog**
drive CIDR value for the rules from node IPv4 and IPv6 addresses