### PR TITLE
E2E: Add platform pkg to detect running on OCP cluster type

### DIFF
--- a/config/openshift/namespace.yaml
+++ b/config/openshift/namespace.yaml
@@ -10,5 +10,5 @@ metadata:
     openshift.io/node-selector: ""
     openshift.io/description: "Openshift ingress node firewall components"
     workload.openshift.io/allowed: "management"
-  name: system
+  name: openshift-ingress-node-firewall
 

--- a/controllers/ingressnodefirewallconfig_controller.go
+++ b/controllers/ingressnodefirewallconfig_controller.go
@@ -22,6 +22,7 @@ import (
 
 	ingressnodefwv1alpha1 "github.com/openshift/ingress-node-firewall/api/v1alpha1"
 	"github.com/openshift/ingress-node-firewall/pkg/apply"
+	"github.com/openshift/ingress-node-firewall/pkg/platform"
 	"github.com/openshift/ingress-node-firewall/pkg/render"
 
 	"github.com/go-logr/logr"
@@ -44,9 +45,10 @@ var ManifestPath = IngressNodeFirewallManifestPath
 // IngressNodeFirewallConfigReconciler reconciles a IngressNodeFirewallConfig object
 type IngressNodeFirewallConfigReconciler struct {
 	client.Client
-	Scheme    *runtime.Scheme
-	Log       logr.Logger
-	Namespace string
+	Scheme       *runtime.Scheme
+	Log          logr.Logger
+	Namespace    string
+	PlatformInfo platform.PlatformInfo
 }
 
 // +kubebuilder:rbac:groups=apps,namespace=ingress-node-firewall-system,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
@@ -107,6 +109,7 @@ func (r *IngressNodeFirewallConfigReconciler) syncIngressNodeFwConfigResources(c
 	data.Data["Image"] = os.Getenv("DAEMONSET_IMAGE")
 	data.Data["NameSpace"] = r.Namespace
 	data.Data["RBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
+	data.Data["IsOpenShift"] = r.PlatformInfo.IsOpenShift()
 
 	objs, err := render.RenderDir(ManifestPath, &data)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 
 	ingressnodefwv1alpha1 "github.com/openshift/ingress-node-firewall/api/v1alpha1"
 	"github.com/openshift/ingress-node-firewall/controllers"
+	"github.com/openshift/ingress-node-firewall/pkg/platform"
 	"github.com/openshift/ingress-node-firewall/pkg/version"
 	"github.com/openshift/ingress-node-firewall/pkg/webhook"
 
@@ -123,11 +124,19 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
+	cfg := ctrl.GetConfigOrDie()
+	platformInfo, err := platform.GetPlatformInfo(cfg)
+	if err != nil {
+		setupLog.Error(err, "unable to get platform name")
+		os.Exit(1)
+	}
 	if err = (&controllers.IngressNodeFirewallConfigReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Log:       ctrl.Log.WithName("controllers").WithName("IngressNodeFirewallConfig"),
-		Namespace: nameSpace,
+		Client:       mgr.GetClient(),
+		Scheme:       mgr.GetScheme(),
+		Log:          ctrl.Log.WithName("controllers").WithName("IngressNodeFirewallConfig"),
+		Namespace:    nameSpace,
+		PlatformInfo: platformInfo,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IngressNodeFirewallConfig")
 		os.Exit(1)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1,0 +1,104 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+var log = ctrl.Log.WithName("platform")
+
+type k8SBasedPlatformVersioner struct{}
+
+/*
+GetPlatformInfo examines the Kubernetes-based environment and determines the running platform, version, & OS.
+Accepts <nil> or instantiated 'cfg' rest config parameter.
+
+Result: PlatformInfo{ Name: OpenShift, K8SVersion: 1.13+, OS: linux/amd64 }
+*/
+func GetPlatformInfo(cfg *rest.Config) (PlatformInfo, error) {
+	return k8SBasedPlatformVersioner{}.getPlatformInfo(nil, cfg)
+}
+
+/*
+GetPlatformName is a helper method to return the platform name from GetPlatformInfo results
+Accepts <nil> or instantiated 'cfg' rest config parameter.
+*/
+func GetPlatformName(cfg *rest.Config) (string, error) {
+	info, err := GetPlatformInfo(cfg)
+	if err != nil {
+		return "", err
+	}
+	return string(info.Name), nil
+}
+
+// deal with cfg coming from legacy method signature and allow injection for client testing
+func (k8SBasedPlatformVersioner) defaultArgs(client discovery.DiscoveryInterface, cfg *rest.Config) (discovery.DiscoveryInterface, *rest.Config, error) {
+	if cfg == nil {
+		var err error
+		cfg, err = config.GetConfig()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	if client == nil {
+		var err error
+		client, err = discovery.NewDiscoveryClientForConfig(cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return client, cfg, nil
+}
+
+func (pv k8SBasedPlatformVersioner) getPlatformInfo(client discovery.DiscoveryInterface, cfg *rest.Config) (PlatformInfo, error) {
+	log.Info("detecting platform version...")
+	info := PlatformInfo{Name: Kubernetes}
+
+	var err error
+	client, _, err = pv.defaultArgs(client, cfg)
+	if err != nil {
+		log.Info("issue occurred while defaulting client/cfg args")
+		return info, err
+	}
+
+	k8sVersion, err := client.ServerVersion()
+	if err != nil {
+		log.Info("issue occurred while fetching ServerVersion")
+		return info, err
+	}
+	info.K8SVersion = k8sVersion.Major + "." + k8sVersion.Minor
+	info.OS = k8sVersion.Platform
+
+	apiList, err := client.ServerGroups()
+	if err != nil {
+		log.Info("issue occurred while fetching ServerGroups")
+		return info, err
+	}
+
+	for _, v := range apiList.Groups {
+		if v.Name == "route.openshift.io" {
+
+			log.Info("route.openshift.io found in apis, platform is OpenShift")
+			info.Name = OpenShift
+			break
+		}
+	}
+	log.Info(info.String())
+	return info, nil
+}

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -1,0 +1,41 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import "fmt"
+
+type PlatformType string
+
+const (
+	OpenShift  PlatformType = "OpenShift"
+	Kubernetes PlatformType = "Kubernetes"
+)
+
+type PlatformInfo struct {
+	Name       PlatformType `json:"name"`
+	K8SVersion string       `json:"k8sVersion"`
+	OS         string       `json:"os"`
+}
+
+func (info PlatformInfo) IsOpenShift() bool {
+	return info.Name == OpenShift
+}
+
+func (info PlatformInfo) String() string {
+	return "PlatformInfo [" +
+		"Name: " + fmt.Sprintf("%v", info.Name) +
+		", K8SVersion: " + info.K8SVersion +
+		", OS: " + info.OS + "]"
+}


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

**- What this PR does and why is it needed**
add pkg to detect if running on OCP cluster or not to customize securityContext


**- How to verify it**
e2e was extended to check the cluster type

