### PR TITLE
manifests/daemonset: Use an init container to mount bpffs

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -21,11 +21,25 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: "system-node-critical"
+      initContainers:
+        - name: mount-bpffs
+          image: '{{.Image}}'
+          command: ['mount', 'bpffs', '/sys/fs/bpf', '-t', 'bpf']
+          securityContext:
+            privileged: true
+            runAsUser: 0
+            capabilities:
+              add:
+                - CAP_BPF
+                - CAP_NET_ADMIN
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: bpf-maps
+              mountPath: /sys/fs/bpf
+              mountPropagation: Bidirectional
       containers:
         - name: daemon
           image: '{{.Image}}'
-          command: ['/bin/sh', '-c', 'mount bpffs /sys/fs/bpf -t bpf && /usr/bin/daemon']
-          #- command: ['/bin/sh', '-c', 'mount bpffs /sys/fs/bpf -t bpf && strace -fe trace=bpf /usr/bin/daemon']
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
Use an initContainer to mount the BPF file system. The goal here is to
separate the concerns when the daemon is started.

This would also allow us to drop the command reference (i.e.,
'/usr/bin/daemon') and rely on the entrypoint specified in the
Dockerfile.
