### PR TITLE
Makefile: use SHELLFLAGS to carry all shell flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ endif
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
-.SHELLFLAGS = -ec
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -eu -o pipefail -c
 
 .PHONY: all
 all: build


### PR DESCRIPTION
The SHELL and SHELLFLAGS settings seem conflated to me. This change
moves all shell options into SHELLFLAGS, leaving SHELL to reference
the desired shell name.

There is an additional semantic change with the `-u` flag (error on any undefined value) which I think is really just best practice.
