### PR TITLE
Makefile: explicitly set KUBEBUILDER_ASSETS for test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS_DIR)/bin" go test ./... -coverprofile cover.out
 
 .PHONY: create-kind-cluster 
 create-kind-cluster: ## Create a kind cluster.


### PR DESCRIPTION
If I run:

```console
$ make -n test
echo "==== Generating DaemonSet manifest"
hack/generate-daemon-manifest.sh
/home/aim/src/github.com/openshift/ingress-node-firewall/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/home/aim/src/github.com/openshift/ingress-node-firewall/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
GOBIN=/home/aim/src/github.com/openshift/ingress-node-firewall/bin
mkdir -p /home/aim/src/github.com/openshift/ingress-node-firewall/testbin
test -f /home/aim/src/github.com/openshift/ingress-node-firewall/testbin/setup-envtest.sh || curl -sSLo /home/aim/src/github.com/openshift/ingress-node-firewall/testbin/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
source /home/aim/src/github.com/openshift/ingress-node-firewall/testbin/setup-envtest.sh; fetch_envtest_tools /home/aim/src/github.com/openshift/ingress-node-firewall/testbin; setup_envtest_env /home/aim/src/github.com/openshift/ingress-node-firewall/testbin;
bash: line 1: /home/aim/src/github.com/openshift/ingress-node-firewall/bin/setup-envtest: No such file or directory
KUBEBUILDER_ASSETS="" go test ./... -coverprofile cover.out
```

Then I get this bash^^ error.

This is because nothing in the Makefile creates the following file:

```
github.com/openshift/ingress-node-firewall/bin/setup-envtest
```

Given that we explicitly download the kube assets let's reference that
directory explicitly, particularly as we want the build to be both
repeatable and use known versions of etcd, et al).

If things ordinarily work without this commit that's because the test
infra will look for the binaries in `/usr/local/kubebuilder/bin`.

With this change I now see:

```console
$ make -n test
echo "==== Generating DaemonSet manifest"
 ...
KUBEBUILDER_ASSETS="/home/aim/src/github.com/openshift/ingress-node-firewall/testbin/bin" go test ./... -coverprofile cover.out
```
