### PR TITLE
fix rules test cases and fix a couple of lint errors

### DIFF
--- a/controllers/ingressnodefirewall_controller.go
+++ b/controllers/ingressnodefirewall_controller.go
@@ -378,7 +378,7 @@ func mergeRuleSet(a, b []infv1alpha1.IngressNodeFirewallRules) ([]infv1alpha1.In
 			// Now, go over each existing rule in the already merged slice.
 			for i, ruleA := range a {
 				if len(ruleA.SourceCIDRs) != 1 {
-					return nil, fmt.Errorf(
+					return []infv1alpha1.IngressNodeFirewallRules{}, fmt.Errorf(
 						"cannot merge into ruleset A with invalid SourceCIDRs: '%v'", ruleA.SourceCIDRs)
 				}
 				// If the CIDR already exists in A, then merge it in and continue with the next CIDR.
@@ -386,7 +386,7 @@ func mergeRuleSet(a, b []infv1alpha1.IngressNodeFirewallRules) ([]infv1alpha1.In
 					a[i].FirewallProtocolRules, err = mergeFirewallProtocolRules(
 						ruleA.FirewallProtocolRules, ruleB.FirewallProtocolRules)
 					if err != nil {
-						return nil, err
+						return []infv1alpha1.IngressNodeFirewallRules{}, err
 					}
 					continue withNextSourceCIDR
 				}

--- a/pkg/ebpf/ingress_node_firewall_events.go
+++ b/pkg/ebpf/ingress_node_firewall_events.go
@@ -103,43 +103,66 @@ func (infc *IngNodeFwController) ingressNodeFwEvents() error {
 				log.Printf("lookup network iface %d: %s", eventHdr.IfId, err)
 				continue
 			}
-			eventsLogger.Info(fmt.Sprintf("ruleId %d action %s len %d if %s\n",
-				eventHdr.RuleId, convertXdpActionToString(eventHdr.Action), eventHdr.PktLength, iface.Name))
+			if err := eventsLogger.Info(fmt.Sprintf("ruleId %d action %s len %d if %s\n",
+				eventHdr.RuleId, convertXdpActionToString(eventHdr.Action), eventHdr.PktLength, iface.Name)); err != nil {
+				log.Printf("syslog event logging failed %q", err)
+			}
 			decodePacket := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
 			// check for IPv4
 			if ip4Layer := decodePacket.Layer(layers.LayerTypeIPv4); ip4Layer != nil {
 				ip, _ := ip4Layer.(*layers.IPv4)
-				eventsLogger.Info(fmt.Sprintf("\tipv4 src addr %s dst addr %s\n", ip.SrcIP.String(), ip.DstIP.String()))
+				if err := eventsLogger.Info(fmt.Sprintf("\tipv4 src addr %s dst addr %s\n", ip.SrcIP.String(), ip.DstIP.String())); err != nil {
+					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
+						eventHdr.RuleId, iface.Name, err)
+				}
 			}
 			// check for IPv6
 			if ip6Layer := decodePacket.Layer(layers.LayerTypeIPv6); ip6Layer != nil {
 				ip, _ := ip6Layer.(*layers.IPv6)
-				eventsLogger.Info(fmt.Sprintf("\tipv6 src addr %s dst addr %s\n", ip.SrcIP.String(), ip.DstIP.String()))
+				if err := eventsLogger.Info(fmt.Sprintf("\tipv6 src addr %s dst addr %s\n", ip.SrcIP.String(), ip.DstIP.String())); err != nil {
+					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
+						eventHdr.RuleId, iface.Name, err)
+				}
 			}
 			// check for TCP
 			if tcpLayer := decodePacket.Layer(layers.LayerTypeTCP); tcpLayer != nil {
 				tcp, _ := tcpLayer.(*layers.TCP)
-				eventsLogger.Info(fmt.Sprintf("\ttcp srcPort %d dstPort %d\n", tcp.SrcPort, tcp.DstPort))
+				if err := eventsLogger.Info(fmt.Sprintf("\ttcp srcPort %d dstPort %d\n", tcp.SrcPort, tcp.DstPort)); err != nil {
+					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
+						eventHdr.RuleId, iface.Name, err)
+				}
 			}
 			// check for UDP
 			if udpLayer := decodePacket.Layer(layers.LayerTypeUDP); udpLayer != nil {
 				udp, _ := udpLayer.(*layers.UDP)
-				eventsLogger.Info(fmt.Sprintf("\tudp srcPort %d dstPort %d\n", udp.SrcPort, udp.DstPort))
+				if err := eventsLogger.Info(fmt.Sprintf("\tudp srcPort %d dstPort %d\n", udp.SrcPort, udp.DstPort)); err != nil {
+					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
+						eventHdr.RuleId, iface.Name, err)
+				}
 			}
 			// check fo SCTP
 			if sctpLayer := decodePacket.Layer(layers.LayerTypeSCTP); sctpLayer != nil {
 				sctp, _ := sctpLayer.(*layers.SCTP)
-				eventsLogger.Info(fmt.Sprintf("\tsctp srcPort %d dstPort %d\n", sctp.SrcPort, sctp.DstPort))
+				if err := eventsLogger.Info(fmt.Sprintf("\tsctp srcPort %d dstPort %d\n", sctp.SrcPort, sctp.DstPort)); err != nil {
+					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
+						eventHdr.RuleId, iface.Name, err)
+				}
 			}
 			// check for ICMPv4
 			if icmpv4Layer := decodePacket.Layer(layers.LayerTypeICMPv4); icmpv4Layer != nil {
 				icmp, _ := icmpv4Layer.(*layers.ICMPv4)
-				eventsLogger.Info(fmt.Sprintf("\ticmpv4 type %d code %d\n", icmp.TypeCode.Type(), icmp.TypeCode.Code()))
+				if err := eventsLogger.Info(fmt.Sprintf("\ticmpv4 type %d code %d\n", icmp.TypeCode.Type(), icmp.TypeCode.Code())); err != nil {
+					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
+						eventHdr.RuleId, iface.Name, err)
+				}
 			}
 			// check for ICMPV6
 			if icmpv6Layer := decodePacket.Layer(layers.LayerTypeICMPv6); icmpv6Layer != nil {
 				icmp, _ := icmpv6Layer.(*layers.ICMPv6)
-				eventsLogger.Info(fmt.Sprintf("\ticmpv6 type %d code %d\n", icmp.TypeCode.Type(), icmp.TypeCode.Code()))
+				if err := eventsLogger.Info(fmt.Sprintf("\ticmpv6 type %d code %d\n", icmp.TypeCode.Type(), icmp.TypeCode.Code())); err != nil {
+					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
+						eventHdr.RuleId, iface.Name, err)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
**- What this PR does and why is it needed**
- fix failing ut test cases path from @andreaskaris 
- fix lint issue in the event code.


**- How to verify it**
- make test
```bash
KUBEBUILDER_ASSETS="/home/mmahmoud/go/src/ingress-node-firewall/testbin/bin" go test ./... -coverprofile cover.out
?       github.com/openshift/ingress-node-firewall      [no test files]
?       github.com/openshift/ingress-node-firewall/api/v1alpha1 [no test files]
?       github.com/openshift/ingress-node-firewall/cmd/daemon   [no test files]
?       github.com/openshift/ingress-node-firewall/cmd/syslog   [no test files]
ok      github.com/openshift/ingress-node-firewall/controllers  10.645s coverage: 77.5% of statements
?       github.com/openshift/ingress-node-firewall/pkg/apply    [no test files]
ok      github.com/openshift/ingress-node-firewall/pkg/ebpf     0.036s  coverage: 0.0% of statements
ok      github.com/openshift/ingress-node-firewall/pkg/ebpfsyncer       0.018s  coverage: 0.0% of statements
?       github.com/openshift/ingress-node-firewall/pkg/failsaferules    [no test files]
ok      github.com/openshift/ingress-node-firewall/pkg/interfaces       0.003s  coverage: 25.0% of statements
?       github.com/openshift/ingress-node-firewall/pkg/metrics  [no test files]
?       github.com/openshift/ingress-node-firewall/pkg/platform [no test files]
ok      github.com/openshift/ingress-node-firewall/pkg/render   0.024s  coverage: 78.8% of statements
ok      github.com/openshift/ingress-node-firewall/pkg/status   0.017s  coverage: 41.4% of statements
?       github.com/openshift/ingress-node-firewall/pkg/utils    [no test files]
?       github.com/openshift/ingress-node-firewall/pkg/version  [no test files]
ok      github.com/openshift/ingress-node-firewall/pkg/webhook  7.027s  coverage: 85.3% of statements
?       github.com/openshift/ingress-node-firewall/test/consts  [no test files]
?       github.com/openshift/ingress-node-firewall/test/e2e/client      [no test files]
?       github.com/openshift/ingress-node-firewall/test/e2e/functional/tests    [no test files]
?       github.com/openshift/ingress-node-firewall/test/e2e/ingress-node-firewall       [no test files]
?       github.com/openshift/ingress-node-firewall/test/e2e/k8sreporter [no test files]
?       github.com/openshift/ingress-node-firewall/test/e2e/namespaces  [no test files]
?       github.com/openshift/ingress-node-firewall/test/e2e/pods        [no test files]
?       github.com/openshift/ingress-node-firewall/test/e2e/validation/tests    [no test files]
```

- make test-e2e
```bash
JUnit report was created: /tmp/test_e2e_logs/e2e_junit.xml

Ran 11 of 11 Specs in 265.334 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
```