### PR TITLE
Dockerfile: use vendor directory when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+
+COPY vendor/ vendor/
 
 # Copy the go source
 COPY main.go main.go
@@ -17,7 +16,7 @@ COPY pkg/ pkg/
 COPY bindata/manifests/ bindata/manifests/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
Avoid the call to 'go mod download' as that doesn't necessarily give
us a reproducible build. In Dockerfile.daemon we already copy the
vendor directory so we should be consistent.

