### PR TITLE
Trigger nodeState reconcilation only for fwobj with matching node's label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,10 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS_DIR)/bin" go test ./... -coverprofile cover.out
 
+.PHONY: test-race
+test-race: manifests generate fmt vet envtest ## Run tests and check for race conditions.
+	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS_DIR)/bin" go test -race ./...
+
 .PHONY: create-kind-cluster 
 create-kind-cluster: ## Create a kind cluster.
 	hack/kind-cluster.sh

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the ingress-nodefw v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=ingressnodefirewall.openshift.io
+// +kubebuilder:object:generate=true
+// +groupName=ingressnodefirewall.openshift.io
 package v1alpha1
 
 import (

--- a/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewallconfigs.yaml
+++ b/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewallconfigs.yaml
@@ -95,8 +95,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallconfigs.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallconfigs.yaml
@@ -96,8 +96,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"

--- a/controllers/ingressnodefirewallconfig_controller.go
+++ b/controllers/ingressnodefirewallconfig_controller.go
@@ -93,6 +93,7 @@ func (r *IngressNodeFirewallConfigReconciler) Reconcile(ctx context.Context, req
 
 	if err = r.syncIngressNodeFwConfigResources(ctx, instance); err != nil {
 		condition = status.ConditionDegraded
+		err = errors.Wrapf(err, "FailedToSyncIngressNodeFirewallConfigResources")
 	} else {
 		err = status.IsIngressNodeFirewallConfigAvailable(ctx, r.Client, req.NamespacedName.Namespace)
 		if err != nil {

--- a/controllers/ingressnodefirewallnodestate_controller_test.go
+++ b/controllers/ingressnodefirewallnodestate_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	infv1alpha1 "github.com/openshift/ingress-node-firewall/api/v1alpha1"
@@ -16,13 +17,16 @@ import (
 )
 
 var ingressNodeFirewallRules map[string][]infv1alpha1.IngressNodeFirewallRules
+var m sync.Mutex
 
 // ebpfSingletonMock implements ebpfDaemon.
 type ebpfSingletonMock struct{}
 
 func (e *ebpfSingletonMock) SyncInterfaceIngressRules(
 	ifaceIngressRules map[string][]infv1alpha1.IngressNodeFirewallRules, isDelete bool) error {
+	m.Lock()
 	ingressNodeFirewallRules = ifaceIngressRules
+	m.Unlock()
 	return nil
 }
 

--- a/controllers/ingressnodefirewallnodestate_controller_test.go
+++ b/controllers/ingressnodefirewallnodestate_controller_test.go
@@ -104,7 +104,10 @@ var _ = Describe("IngressNodeFirewallNodeState controller", func() {
 		It(fmt.Sprintf("eBPF rule reconciliation for node %s should be triggered", daemonReconcilerNodeName), func() {
 			By("Checking that the reconciler was called")
 			Eventually(func() bool {
-				return len(ingressNodeFirewallRules) == 2
+				m.Lock()
+				l := len(ingressNodeFirewallRules)
+				m.Unlock()
+				return l == 2
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -143,7 +143,6 @@ var _ = AfterSuite(func() {
 		log.Printf("failed to shut down testEnv err %v", err)
 	}
 	By("tearing down the test environment")
-	ManifestPath = IngressNodeFirewallManifestPath
 	if err := testEnv.Stop(); err != nil {
 		log.Printf("failed to shut down testEnv err %v", err)
 	}

--- a/pkg/ebpf/bpf_bpfeb.go
+++ b/pkg/ebpf/bpf_bpfeb.go
@@ -65,9 +65,9 @@ func LoadBpf() (*ebpf.CollectionSpec, error) {
 //
 // The following types are suitable as obj argument:
 //
-//     *BpfObjects
-//     *BpfPrograms
-//     *BpfMaps
+//	*BpfObjects
+//	*BpfPrograms
+//	*BpfMaps
 //
 // See ebpf.CollectionSpec.LoadAndAssign documentation for details.
 func LoadBpfObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
@@ -158,5 +158,6 @@ func _BpfClose(closers ...io.Closer) error {
 }
 
 // Do not access this directly.
+//
 //go:embed bpf_bpfeb.o
 var _BpfBytes []byte

--- a/pkg/ebpf/bpf_bpfel.go
+++ b/pkg/ebpf/bpf_bpfel.go
@@ -65,9 +65,9 @@ func LoadBpf() (*ebpf.CollectionSpec, error) {
 //
 // The following types are suitable as obj argument:
 //
-//     *BpfObjects
-//     *BpfPrograms
-//     *BpfMaps
+//	*BpfObjects
+//	*BpfPrograms
+//	*BpfMaps
 //
 // See ebpf.CollectionSpec.LoadAndAssign documentation for details.
 func LoadBpfObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
@@ -158,5 +158,6 @@ func _BpfClose(closers ...io.Closer) error {
 }
 
 // Do not access this directly.
+//
 //go:embed bpf_bpfel.o
 var _BpfBytes []byte

--- a/pkg/ebpf/ingress_node_firewall_loader.go
+++ b/pkg/ebpf/ingress_node_firewall_loader.go
@@ -87,11 +87,15 @@ func NewIngNodeFwController() (*IngNodeFwController, error) {
 // IngressNodeFwRulesLoader executes the following actions in order:
 // i)   Get eBPF objs to create/update eBPF maps and get map info.
 // ii)  Build a map of valid ebpfKeys pointing to the ebpfRules that should be associated to them (built from
-//      ifaceIngressRules).
+//
+//	ifaceIngressRules).
+//
 // iii) Get stale keys (= keys inside the eBPF map but not inside the currently desired ruleset).
 // iv)  Purge all stale keys from the eBPF map.
 // v)   Add/update all keys. This is an idempotent action and non-existing keys are added whereas existing keys
-//      are updated.
+//
+//	are updated.
+//
 // vi)  Generate ingress node firewall events.
 // In the context of this method, stale keys are keys that figure inside the eBPF map but that are not generated
 // during step ii) from the provided ingressRules slice.
@@ -525,6 +529,7 @@ func (infc *IngNodeFwController) getStaleKeys(desiredKeys []BpfLpmIpKeySt) ([]Bp
 
 // getStaleInterfaceKeys returns the keys for all rules that belong to stale interfaces, meaning interfaces
 // that are not attached any more.
+//
 //nolint:golint,unused
 func (infc *IngNodeFwController) getStaleInterfaceKeys() ([]BpfLpmIpKeySt, error) {
 	objs := infc.objs

--- a/pkg/metrics/statistics.go
+++ b/pkg/metrics/statistics.go
@@ -166,7 +166,7 @@ func updateMetrics(stopCh <-chan struct{}, statsMap *ebpf.Map, period time.Durat
 	}
 }
 
-//addUInt64 performs op and checks for overflow. Returns value, and true for success.
+// addUInt64 performs op and checks for overflow. Returns value, and true for success.
 func addUInt64Float64(a uint64, b float64) (float64, bool) {
 	c := float64(a) + b
 	if a == 0 || b == 0 {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -42,13 +42,12 @@ const (
 // Update updates ingress node firewall config object status field.
 func Update(ctx context.Context, client k8sclient.Client, infcfg *ingressnodefwv1alpha1.IngressNodeFirewallConfig, condition string, reason string, message string) error {
 	conditions := getConditions(condition, reason, message)
-	if equality.Semantic.DeepEqual(conditions, infcfg.Status.Conditions) {
-		return nil
-	}
-	infcfg.Status.Conditions = conditions
-
-	if err := client.Status().Update(ctx, infcfg); err != nil {
-		return errors.Wrapf(err, "could not update status for object %+v", infcfg)
+	cfg := infcfg.DeepCopy()
+	if !equality.Semantic.DeepEqual(conditions, cfg.Status.Conditions) {
+		cfg.Status.Conditions = conditions
+		if err := client.Status().Update(ctx, cfg); err != nil {
+			return errors.Wrapf(err, "could not update status for object %+v", cfg)
+		}
 	}
 	return nil
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -29,7 +29,7 @@ type (
 	uint32Set map[uint32]empty
 )
 
-//+kubebuilder:webhook:path=/validate-ingressnodefirewall-openshift-io-v1alpha1-ingressnodefirewall,mutating=false,failurePolicy=fail,sideEffects=None,groups=ingressnodefirewall.openshift.io,resources=ingressnodefirewalls,verbs=create;update,versions=v1alpha1,name=vingressnodefirewall.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-ingressnodefirewall-openshift-io-v1alpha1-ingressnodefirewall,mutating=false,failurePolicy=fail,sideEffects=None,groups=ingressnodefirewall.openshift.io,resources=ingressnodefirewalls,verbs=create;update,versions=v1alpha1,name=vingressnodefirewall.kb.io,admissionReviewVersions=v1
 var _ webhook.CustomValidator = &IngressNodeFirewallWebhook{ingressnodefwv1alpha1.IngressNodeFirewall{}}
 
 var (


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

**- What this PR does and why is it needed**
- trigger nodeState reconciler only if fwobj nodeselector match node object label
- add `make test-race` to detect race conditions.

**- How to verify it**
- ran UT
- ran e2e on kind and it passed with those changes
```
JUnit report was created: /tmp/test_e2e_logs/e2e_junit.xml

Ran 11 of 11 Specs in 331.492 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
```