### PR TITLE
E2E: allow running on single stack cluster while the  default still dualstack

### DIFF
--- a/controllers/ingressnodefirewallconfig_controller.go
+++ b/controllers/ingressnodefirewallconfig_controller.go
@@ -106,6 +106,7 @@ func (r *IngressNodeFirewallConfigReconciler) Reconcile(ctx context.Context, req
 	}
 
 	if err != nil {
+		errorMsg = err.Error()
 		if errors.Unwrap(err) != nil {
 			wrappedErrMsg = errors.Unwrap(err).Error()
 		}

--- a/test/e2e/ingress-node-firewall/ingress-node-firewall.go
+++ b/test/e2e/ingress-node-firewall/ingress-node-firewall.go
@@ -106,7 +106,7 @@ func NodesIPs(nodes []v1.Node) []string {
 	return res
 }
 
-func GetRuleCIDR(nodes []v1.Node) (string, string, error) {
+func GetRuleCIDR(isSingleStack bool, nodes []v1.Node) (string, string, error) {
 	var v4CIDR, v6CIDR string
 	v4CIDRLen := 12
 	v6CIDRLen := 64
@@ -121,6 +121,9 @@ func GetRuleCIDR(nodes []v1.Node) (string, string, error) {
 			v6CIDR = fmt.Sprintf("%s/%d", addr.Mask(v6Mask), v6CIDRLen)
 		} else {
 			return "", "", fmt.Errorf("invalid ip address family %s", ip)
+		}
+		if isSingleStack && (v4CIDR != "" || v6CIDR != "") {
+			break
 		}
 		if v4CIDR != "" && v6CIDR != "" {
 			break


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

Passed KinD e2e test run
```
JUnit report was created: /tmp/test_e2e_logs/e2e_junit.xml

Ran 11 of 11 Specs in 382.665 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped


```

