### PR TITLE
fix incorrect webhook verification error when editing existing rule

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -338,10 +338,11 @@ func validateAgainstExistingINFs(allErrs field.ErrorList, infList *ingressnodefw
 	return allErrs
 }
 
-func isOrderOverlapping(rulesA []ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule, rulesB []ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule) bool {
-	for _, ruleA := range rulesA {
-		for _, ruleB := range rulesB {
-			if ruleA.Order == ruleB.Order {
+func isOrderOverlapping(oldRules, newRules []ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule) bool {
+	for oldIdx, oldRule := range oldRules {
+		for newIdx, newRule := range newRules {
+			// make sure rules index is different otherwise could be an update to existing rule.
+			if oldRule.Order == newRule.Order && oldIdx != newIdx {
 				return true
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

- verified edit take effect with no error
- verified when edit existing yaml and duplicate rule error fire actually from the OpenAPI schema validation, I think there is still a value having 2nd line of defense for order dup in webhook if it deems will never trigger we can remove that check.
`The IngressNodeFirewall "ingressnodefirewall-demo2" is invalid: spec.ingress[0].rules[1]: Duplicate value: map[string]interface {}{"order":10}
`