### PR TITLE
Fix missing namespace declaration for OCP

### DIFF
--- a/config/openshift/kustomization.yaml
+++ b/config/openshift/kustomization.yaml
@@ -14,6 +14,7 @@ bases:
   - ../manager
   - ../webhook
   - ../prometheus
+  - namespace.yaml
   - rbac.yaml
 
 patchesStrategicMerge:


### PR DESCRIPTION
Following the readme steps, I noticed that the ns
for OCP isn't being created.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>
