### PR TITLE
OCPBUGS-1621: fix version to allow art build with the proper version with timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+VERSION ?= 4.12.0
 CSV_VERSION = $(shell echo $(VERSION) | sed 's/v//')
 ifeq ($(VERSION), latest)
 CSV_VERSION := 0.0.0

--- a/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
+++ b/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
@@ -89,9 +89,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    olm.skipRange: '>=4.11.0 <4.12.0'
     operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: ingress-node-firewall.v0.0.1
+  name: ingress-node-firewall.v4.12.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -420,6 +421,9 @@ spec:
     type: AllNamespaces
   keywords:
   - ingressnodefirewall
+  labels:
+    olm-owner-enterprise-app: ingress-node-firewall
+    olm-status-descriptors: ingress-node-firewall.v4.12.0
   links:
   - name: Ingress Node Firewall
     url: https://ingress-node-firewall.domain
@@ -429,7 +433,7 @@ spec:
   maturity: alpha
   provider:
     name: RedHat
-  version: 0.0.1
+  version: 4.12.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
+++ b/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    olm.skipRange: '>=4.11.0 <4.12.0'
   name: ingress-node-firewall.v0.0.0
   namespace: placeholder
 spec:
@@ -48,6 +49,9 @@ spec:
     type: AllNamespaces
   keywords:
   - ingressnodefirewall
+  labels:
+    olm-owner-enterprise-app: ingress-node-firewall
+    olm-status-descriptors: ingress-node-firewall.v4.12.0
   links:
   - name: Ingress Node Firewall
     url: https://ingress-node-firewall.domain

--- a/config/olm-install/install-resources.yaml
+++ b/config/olm-install/install-resources.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: ingress-node-firewall-system
 spec:
   displayName: Ingress Node Firewall Index
-  image: quay.io/openshift/ingress-nodefw/ingress-node-firewall-index:v0.0.1
+  image: quay.io/openshift/ingress-nodefw/ingress-node-firewall-index:v4.12.0
   publisher: github.com/openshift/ingress-node-firewall
   sourceType: grpc
 ---

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -89,9 +89,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    olm.skipRange: '>=4.11.0 <4.12.0'
     operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: ingress-node-firewall.v0.0.1
+  name: ingress-node-firewall.v4.12.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -420,6 +421,9 @@ spec:
     type: AllNamespaces
   keywords:
   - ingressnodefirewall
+  labels:
+    olm-owner-enterprise-app: ingress-node-firewall
+    olm-status-descriptors: ingress-node-firewall.v4.12.0
   links:
   - name: Ingress Node Firewall
     url: https://ingress-node-firewall.domain
@@ -429,7 +433,7 @@ spec:
   maturity: alpha
   provider:
     name: RedHat
-  version: 0.0.1
+  version: 4.12.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/openshift-ci/wait_for_csv.sh
+++ b/openshift-ci/wait_for_csv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=${VERSION:-"v0.0.1"}
+VERSION=${VERSION:-"v4.12.0"}
 CSV_NAME="ingress-node-firewall.${VERSION}"
 NAMESPACE=${NAMESPACE:-"openshift-ingress-node-firewall"}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,5 +3,5 @@ package version
 var (
 	// Version contains the version number. This will be replaced by the linker at build
 	// time.
-	Version = "0.0.1"
+	Version = "4.12.0"
 )


### PR DESCRIPTION
the logic in art.yaml wasn't able to find v0.0.1 in the daily build hence wasn't updating CSV correctly

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

