### PR TITLE
OCPBUGS-2316: Mixing ICMP v4 and v6 config causes a panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 IMG ?= quay.io/openshift/origin-ingress-node-firewall:latest
 DAEMON_IMG ?= quay.io/openshift/origin-ingress-node-firewall-daemon:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.1
+ENVTEST_K8S_VERSION = 1.25.2
 
 # Default namespace
 NAMESPACE ?= ingress-node-firewall-system

--- a/api/v1alpha1/ingressnodefirewall_types.go
+++ b/api/v1alpha1/ingressnodefirewall_types.go
@@ -49,6 +49,11 @@ type IngressNodeFirewallProtoRule struct {
 
 // IngressNodeProtocolConfig is a discriminated union of protocol's specific configuration.
 // +union
+// +kubebuilder:validation:XValidation:rule="has(self.protocol) && self.protocol == 'TCP' ?  has(self.tcp) : !has(self.tcp)",message="tcp is required when protocol is TCP, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.protocol) && self.protocol == 'UDP' ?  has(self.udp) : !has(self.udp)",message="udp is required when protocol is UDP, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.protocol) && self.protocol == 'SCTP' ?  has(self.sctp) : !has(self.sctp)",message="sctp is required when protocol is SCTP, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.protocol) && self.protocol == 'ICMP' ?  has(self.icmp) : !has(self.icmp)",message="icmp is required when protocol is ICMP, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.protocol) && self.protocol == 'ICMPv6' ?  has(self.icmpv6) : !has(self.icmpv6)",message="icmpv6 is required when protocol is ICMPv6, and forbidden otherwise"
 type IngressNodeProtocolConfig struct {
 	// protocol can be ICMP, ICMPv6, TCP, SCTP or UDP.
 	// +unionDiscriminator
@@ -57,22 +62,27 @@ type IngressNodeProtocolConfig struct {
 	Protocol IngressNodeFirewallRuleProtocolType `json:"protocol"`
 
 	// tcp defines an ingress node firewall rule for TCP protocol.
+	// +unionMember
 	// +optional
 	TCP *IngressNodeFirewallProtoRule `json:"tcp,omitempty"`
 
 	// udp defines an ingress node firewall rule for UDP protocol.
+	// +unionMember
 	// +optional
 	UDP *IngressNodeFirewallProtoRule `json:"udp,omitempty"`
 
 	// sctp defines an ingress node firewall rule for SCTP protocol.
+	// +unionMember
 	// +optional
 	SCTP *IngressNodeFirewallProtoRule `json:"sctp,omitempty"`
 
 	// icmp defines an ingress node firewall rule for ICMP protocol.
+	// +unionMember
 	// +optional
 	ICMP *IngressNodeFirewallICMPRule `json:"icmp,omitempty"`
 
 	// icmpv6 defines an ingress node firewall rule for ICMPv6 protocol.
+	// +unionMember
 	// +optional
 	ICMPv6 *IngressNodeFirewallICMPRule `json:"icmpv6,omitempty"`
 }

--- a/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
+++ b/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
@@ -172,6 +172,27 @@ spec:
                               required:
                               - protocol
                               type: object
+                              x-kubernetes-validations:
+                              - message: tcp is required when protocol is TCP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''TCP''
+                                  ?  has(self.tcp) : !has(self.tcp)'
+                              - message: udp is required when protocol is UDP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''UDP''
+                                  ?  has(self.udp) : !has(self.udp)'
+                              - message: sctp is required when protocol is SCTP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''SCTP''
+                                  ?  has(self.sctp) : !has(self.sctp)'
+                              - message: icmp is required when protocol is ICMP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''ICMP''
+                                  ?  has(self.icmp) : !has(self.icmp)'
+                              - message: icmpv6 is required when protocol is ICMPv6,
+                                  and forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''ICMPv6''
+                                  ?  has(self.icmpv6) : !has(self.icmpv6)'
                           required:
                           - order
                           type: object

--- a/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -182,6 +182,27 @@ spec:
                             required:
                             - protocol
                             type: object
+                            x-kubernetes-validations:
+                            - message: tcp is required when protocol is TCP, and forbidden
+                                otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''TCP''
+                                ?  has(self.tcp) : !has(self.tcp)'
+                            - message: udp is required when protocol is UDP, and forbidden
+                                otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''UDP''
+                                ?  has(self.udp) : !has(self.udp)'
+                            - message: sctp is required when protocol is SCTP, and
+                                forbidden otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''SCTP''
+                                ?  has(self.sctp) : !has(self.sctp)'
+                            - message: icmp is required when protocol is ICMP, and
+                                forbidden otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''ICMP''
+                                ?  has(self.icmp) : !has(self.icmp)'
+                            - message: icmpv6 is required when protocol is ICMPv6,
+                                and forbidden otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''ICMPv6''
+                                ?  has(self.icmpv6) : !has(self.icmpv6)'
                         required:
                         - order
                         type: object

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
@@ -173,6 +173,27 @@ spec:
                               required:
                               - protocol
                               type: object
+                              x-kubernetes-validations:
+                              - message: tcp is required when protocol is TCP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''TCP''
+                                  ?  has(self.tcp) : !has(self.tcp)'
+                              - message: udp is required when protocol is UDP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''UDP''
+                                  ?  has(self.udp) : !has(self.udp)'
+                              - message: sctp is required when protocol is SCTP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''SCTP''
+                                  ?  has(self.sctp) : !has(self.sctp)'
+                              - message: icmp is required when protocol is ICMP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''ICMP''
+                                  ?  has(self.icmp) : !has(self.icmp)'
+                              - message: icmpv6 is required when protocol is ICMPv6,
+                                  and forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''ICMPv6''
+                                  ?  has(self.icmpv6) : !has(self.icmpv6)'
                           required:
                           - order
                           type: object

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -172,6 +172,27 @@ spec:
                             required:
                             - protocol
                             type: object
+                            x-kubernetes-validations:
+                            - message: tcp is required when protocol is TCP, and forbidden
+                                otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''TCP''
+                                ?  has(self.tcp) : !has(self.tcp)'
+                            - message: udp is required when protocol is UDP, and forbidden
+                                otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''UDP''
+                                ?  has(self.udp) : !has(self.udp)'
+                            - message: sctp is required when protocol is SCTP, and
+                                forbidden otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''SCTP''
+                                ?  has(self.sctp) : !has(self.sctp)'
+                            - message: icmp is required when protocol is ICMP, and
+                                forbidden otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''ICMP''
+                                ?  has(self.icmp) : !has(self.icmp)'
+                            - message: icmpv6 is required when protocol is ICMPv6,
+                                and forbidden otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''ICMPv6''
+                                ?  has(self.icmpv6) : !has(self.icmpv6)'
                         required:
                         - order
                         type: object

--- a/hack/kind-cluster.sh
+++ b/hack/kind-cluster.sh
@@ -18,7 +18,7 @@ parse_args() {
 
 # deploy_kind installs the kind cluster
 deploy_kind() {
-  cat <<EOF | kind create cluster --image kindest/node:v1.24.0 --config=- --kubeconfig=${DIR}/kubeconfig
+  cat <<EOF | kind create cluster --image kindest/node:v1.25.2 --config=- --kubeconfig=${DIR}/kubeconfig
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:

--- a/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
+++ b/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
@@ -172,6 +172,27 @@ spec:
                               required:
                               - protocol
                               type: object
+                              x-kubernetes-validations:
+                              - message: tcp is required when protocol is TCP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''TCP''
+                                  ?  has(self.tcp) : !has(self.tcp)'
+                              - message: udp is required when protocol is UDP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''UDP''
+                                  ?  has(self.udp) : !has(self.udp)'
+                              - message: sctp is required when protocol is SCTP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''SCTP''
+                                  ?  has(self.sctp) : !has(self.sctp)'
+                              - message: icmp is required when protocol is ICMP, and
+                                  forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''ICMP''
+                                  ?  has(self.icmp) : !has(self.icmp)'
+                              - message: icmpv6 is required when protocol is ICMPv6,
+                                  and forbidden otherwise
+                                rule: 'has(self.protocol) && self.protocol == ''ICMPv6''
+                                  ?  has(self.icmpv6) : !has(self.icmpv6)'
                           required:
                           - order
                           type: object

--- a/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -182,6 +182,27 @@ spec:
                             required:
                             - protocol
                             type: object
+                            x-kubernetes-validations:
+                            - message: tcp is required when protocol is TCP, and forbidden
+                                otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''TCP''
+                                ?  has(self.tcp) : !has(self.tcp)'
+                            - message: udp is required when protocol is UDP, and forbidden
+                                otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''UDP''
+                                ?  has(self.udp) : !has(self.udp)'
+                            - message: sctp is required when protocol is SCTP, and
+                                forbidden otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''SCTP''
+                                ?  has(self.sctp) : !has(self.sctp)'
+                            - message: icmp is required when protocol is ICMP, and
+                                forbidden otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''ICMP''
+                                ?  has(self.icmp) : !has(self.icmp)'
+                            - message: icmpv6 is required when protocol is ICMPv6,
+                                and forbidden otherwise
+                              rule: 'has(self.protocol) && self.protocol == ''ICMPv6''
+                                ?  has(self.icmpv6) : !has(self.icmpv6)'
                         required:
                         - order
                         type: object

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -256,10 +256,14 @@ func validateSourceCIDR(sourceCIDR string) (bool, string) {
 }
 
 func isValidICMPICMPV6Rule(rule ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule) (bool, string) {
-	if rule.ProtocolConfig.ICMP == nil && rule.ProtocolConfig.ICMPv6 == nil {
+	if rule.ProtocolConfig.Protocol == ingressnodefwv1alpha1.ProtocolTypeICMP &&
+		(rule.ProtocolConfig.ICMP == nil || rule.ProtocolConfig.ICMPv6 != nil) {
 		return false, "no ICMP rules defined. Define icmpType/icmpCode"
 	}
-
+	if rule.ProtocolConfig.Protocol == ingressnodefwv1alpha1.ProtocolTypeICMP6 &&
+		(rule.ProtocolConfig.ICMPv6 == nil || rule.ProtocolConfig.ICMP != nil) {
+		return false, "no ICMPv6 rules defined. Define icmpType/icmpCode"
+	}
 	if rule.ProtocolConfig.TCP != nil || rule.ProtocolConfig.UDP != nil || rule.ProtocolConfig.SCTP != nil {
 		return false, "ports are erroneously defined"
 	}

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -197,6 +197,12 @@ var _ = Describe("Rules", func() {
 			inf.Spec.Ingress[0].FirewallProtocolRules[0].ProtocolConfig.TCP = portRule
 			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
 		})
+
+		It("rejects rule with icmpv6 defined", func() {
+			icmp6Rule := &ingressnodefwv1alpha1.IngressNodeFirewallICMPRule{ICMPType: icmpTypeEchoReply}
+			inf.Spec.Ingress[0].FirewallProtocolRules[0].ProtocolConfig.ICMPv6 = icmp6Rule
+			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
+		})
 	})
 
 	Context("protocol is ICMPv6", func() {
@@ -204,7 +210,7 @@ var _ = Describe("Rules", func() {
 
 		BeforeEach(func() {
 			inf = getIngressNodeFirewall("rulesicmpv6")
-			initCIDRICMPRule(inf, ipv6CIDR, validOrder, false, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
+			initCIDRICMPRule(inf, ipv6CIDR, validOrder, true, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
 		})
 
 		It("allows valid rule", func() {
@@ -212,14 +218,20 @@ var _ = Describe("Rules", func() {
 			Expect(deleteIngressNodeFirewall(inf)).To(Succeed())
 		})
 
-		It("rejects rule with no ICMP details defined", func() {
-			inf.Spec.Ingress[0].FirewallProtocolRules[0].ProtocolConfig.ICMP = nil
+		It("rejects rule with no ICMPv6 details defined", func() {
+			inf.Spec.Ingress[0].FirewallProtocolRules[0].ProtocolConfig.ICMPv6 = nil
 			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
 		})
 
 		It("rejects rule with port defined", func() {
 			portRule := &ingressnodefwv1alpha1.IngressNodeFirewallProtoRule{Ports: intstr.FromString(validPort)}
 			inf.Spec.Ingress[0].FirewallProtocolRules[0].ProtocolConfig.TCP = portRule
+			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
+		})
+
+		It("rejects rule with icmp defined", func() {
+			icmpRule := &ingressnodefwv1alpha1.IngressNodeFirewallICMPRule{ICMPType: icmpTypeEchoReply}
+			inf.Spec.Ingress[0].FirewallProtocolRules[0].ProtocolConfig.ICMP = icmpRule
 			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
 		})
 	})


### PR DESCRIPTION
webhhok ICMP and ICMPv6 check was missing
for more details refer to issue #205
manual e2e run results

```
JUnit report was created: /tmp/test_e2e_logs/e2e_junit.xml

Ran 11 of 11 Specs in 168.696 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
```

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

