### PR TITLE
Fix #217 apply rules only for valid interface(s) instead of rejecting the whole config

### DIFF
--- a/pkg/ebpf/ingress_node_firewall_loader.go
+++ b/pkg/ebpf/ingress_node_firewall_loader.go
@@ -113,6 +113,10 @@ func (infc *IngNodeFwController) IngressNodeFwRulesLoader(
 	// Build a map of valid ebpfKeys pointing to the ebpfRules that should be associated to them.
 	ebpfKeyToRules := make(map[BpfLpmIpKeySt]BpfRulesValSt)
 	for interfaceName, ingressRules := range ifaceIngressRules {
+		if !interfaces.IsValidInterfaceNameAndState(interfaceName) {
+			klog.Infof("Fail to load ingress firewall rules invalid interface %s", interfaceName)
+			continue
+		}
 		// Look up the network interface by name.
 		ifID, err := interfaces.GetInterfaceIndex(interfaceName)
 		if err != nil {

--- a/test/e2e/ingress-node-firewall/ingress-node-firewall.go
+++ b/test/e2e/ingress-node-firewall/ingress-node-firewall.go
@@ -122,6 +122,10 @@ func DefineWithInterface(inf *ingressnodefwv1alpha1.IngressNodeFirewall, interfa
 	}
 }
 
+func DefineWithInterfaces(inf *ingressnodefwv1alpha1.IngressNodeFirewall, interfaces []string) {
+	inf.Spec.Interfaces = interfaces
+}
+
 func AppendIngress(inf *ingressnodefwv1alpha1.IngressNodeFirewall, sourceCIDR string, rules ...ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule) {
 	inf.Spec.Ingress = append(inf.Spec.Ingress, ingressnodefwv1alpha1.IngressNodeFirewallRules{
 		SourceCIDRs:           []string{sourceCIDR},


### PR DESCRIPTION
For non existing interfaces we will skip them with an error log in daemon process

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

