### PR TITLE
Fix some new lint errors

### DIFF
--- a/test/e2e/exec/exec.go
+++ b/test/e2e/exec/exec.go
@@ -75,7 +75,7 @@ func ExecCommandWithStdin(cs *testclient.ClientSet, pod *corev1.Pod, stdin strin
 	go func() {
 		defer writer.Close()
 		buf := bytes.NewBufferString(stdin)
-		io.Copy(writer, buf)
+		_, _ = io.Copy(writer, buf)
 	}()
 	var stdout, stderr bytes.Buffer
 	err = exec.Stream(remotecommand.StreamOptions{

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -127,7 +127,7 @@ var _ = Describe("Ingress Node Firewall", func() {
 			testArtifactsLabelString, timeout)).Should(Succeed())
 	})
 
-	Context(fmt.Sprintf("Ingress"), func() {
+	Context("Ingress", func() {
 		var (
 			config             *ingressnodefwv1alpha1.IngressNodeFirewallConfig
 			serverOnePort      = "80"
@@ -1182,7 +1182,7 @@ var _ = Describe("Ingress Node Firewall", func() {
 			infwutils.AppendIngress(inf, "1.1.1.1/32", infwutils.GetTCPRule(1, "40000",
 				ingressnodefwv1alpha1.IngressNodeFirewallDeny))
 			Expect(testclient.Client.Create(context.Background(), inf)).To(Succeed())
-			infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)
+			Expect(infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)).To(Succeed())
 		})
 
 		It("should allow valid ingressnodefirewall UDP rule", func() {
@@ -1194,7 +1194,7 @@ var _ = Describe("Ingress Node Firewall", func() {
 			infwutils.AppendIngress(inf, "1.1.1.1/32", infwutils.GetUDPRule(1, "40000",
 				ingressnodefwv1alpha1.IngressNodeFirewallDeny))
 			Expect(testclient.Client.Create(context.Background(), inf)).To(Succeed())
-			infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)
+			Expect(infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)).To(Succeed())
 		})
 
 		It("should allow valid ingressnodefirewall ICMPV4 rule", func() {
@@ -1206,7 +1206,7 @@ var _ = Describe("Ingress Node Firewall", func() {
 			infwutils.AppendIngress(inf, "1.1.1.1/32", infwutils.GetICMPV4Rule(1, 0, 1,
 				ingressnodefwv1alpha1.IngressNodeFirewallDeny))
 			Expect(testclient.Client.Create(context.Background(), inf)).To(Succeed())
-			infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)
+			Expect(infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)).To(Succeed())
 		})
 
 		It("should allow valid ingressnodefirewall ICMPV6 rule", func() {
@@ -1218,7 +1218,7 @@ var _ = Describe("Ingress Node Firewall", func() {
 			infwutils.AppendIngress(inf, "1:1:1::1/64", infwutils.GetICMPV4Rule(1, 0, 1,
 				ingressnodefwv1alpha1.IngressNodeFirewallDeny))
 			Expect(testclient.Client.Create(context.Background(), inf)).To(Succeed())
-			infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)
+			Expect(infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)).To(Succeed())
 		})
 
 		It("should allow valid ingressnodefirewall SCTP rule", func() {
@@ -1230,7 +1230,7 @@ var _ = Describe("Ingress Node Firewall", func() {
 			infwutils.AppendIngress(inf, "1.1.1.1/32", infwutils.GetSCTPRule(1, "40000",
 				ingressnodefwv1alpha1.IngressNodeFirewallDeny))
 			Expect(testclient.Client.Create(context.Background(), inf)).To(Succeed())
-			infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)
+			Expect(infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)).To(Succeed())
 		})
 
 		It("should block any rules which conflict with failsafe rules", func() {
@@ -1243,7 +1243,6 @@ var _ = Describe("Ingress Node Firewall", func() {
 				infwutils.AppendIngress(inf, "1.1.1.1/32", infwutils.GetTCPRule(1, fmt.Sprintf("%d", tcpFailSafeRule.GetPort()),
 					ingressnodefwv1alpha1.IngressNodeFirewallDeny))
 				Expect(testclient.Client.Create(context.Background(), inf)).ToNot(Succeed())
-				infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)
 			}
 			for _, udpFailSafeRule := range failsaferules.GetUDP() {
 				inf := &ingressnodefwv1alpha1.IngressNodeFirewall{}
@@ -1254,7 +1253,6 @@ var _ = Describe("Ingress Node Firewall", func() {
 				infwutils.AppendIngress(inf, "1.1.1.1/32", infwutils.GetUDPRule(1, fmt.Sprintf("%d", udpFailSafeRule.GetPort()),
 					ingressnodefwv1alpha1.IngressNodeFirewallDeny))
 				Expect(testclient.Client.Create(context.Background(), inf)).ToNot(Succeed())
-				infwutils.DeleteIngressNodeFirewall(testclient.Client, inf, timeout)
 			}
 		})
 	})
@@ -1297,12 +1295,9 @@ func isConnectivitySeen(client *testclient.ClientSet, protocol ingressnodefwv1al
 		return icmp.IsConnectivityOK(client, protocol, sourcePod, destinationIP)
 	} else if infwutils.IsTransportProtocol(protocol) {
 		// Connectivity will be confirmed with server output later and expecting server output to contain clients IP.
-		transport.ConnectToPortFromPod(client, protocol, v6, sourcePod, sourceIP, destinationIP, destinationPort)
+		_, _, _ = transport.ConnectToPortFromPod(client, protocol, v6, sourcePod, sourceIP, destinationIP, destinationPort)
 		serverResult := <-serverResultsCh
-		if strings.Contains(serverResult, sourceIP) {
-			return true
-		}
-		return false
+		return strings.Contains(serverResult, sourceIP)
 	} else {
 		panic("Unexpected protocol")
 	}


### PR DESCRIPTION
new lint errors introduced by #173 showed when ran `make lint` manually not
showing in lint CI run probably an issue in lint CI pipe

```sh
make lint
level=info msg="[config_reader] Config search paths: [./ /app / /root]"
level=info msg="[lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck]"
level=info msg="[loader] Go packages loading at mode 575 (compiled_files|files|imports|name|types_sizes|deps|exports_file) took 26.006633805s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 7.126455ms"
level=info msg="[linters context/goanalysis] analyzers took 1m25.672392686s with top 10 stages: buildir: 1m9.588045374s, nilness: 3.451406769s, inspect: 2.377262097s, printf: 1.46592711s, fact_purity: 1.427937709s, ctrlflow: 1.321752393s, fact_deprecated: 1.196952115s, typedness: 1.171371332s, SA5012: 965.722034ms, S1038: 180.389456ms"
level=warning msg="[linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
level=info msg="[runner] Issues before processing: 14, after processing: 0"
level=info msg="[runner] Processors filtering stat (out/in): nolint: 0/4, exclude: 14/14, exclude-rules: 4/14, identifier_marker: 14/14, filename_unadjuster: 14/14, path_prettifier: 14/14, skip_dirs: 14/14, autogenerated_exclude: 14/14, cgo: 14/14, skip_files: 14/14"
level=info msg="[runner] processing took 2.396373ms with stages: nolint: 1.738974ms, identifier_marker: 212.1µs, autogenerated_exclude: 203.826µs, exclude-rules: 84.083µs, path_prettifier: 81.41µs, skip_dirs: 65.97µs, cgo: 3.182µs, max_same_issues: 1.865µs, filename_unadjuster: 1.284µs, uniq_by_line: 580ns, skip_files: 547ns, diff: 453ns, source_code: 419ns, max_from_linter: 367ns, exclude: 349ns, severity-rules: 223ns, path_shortener: 222ns, max_per_file_from_linter: 205ns, sort_results: 203ns, path_prefixer: 111ns"
level=info msg="[runner] linters took 15.828163846s with stages: goanalysis_metalinter: 15.825623972s, structcheck: 9.721µs"
level=info msg="File cache stats: 0 entries of total size 0B"
level=info msg="Memory: 414 samples, avg is 404.2MB, max is 1294.5MB"
level=info msg="Execution took 41.85094124s"
lint OK!
```
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

