### PR TITLE
E2E test: only pay attention to internal IPs only and explicitly check for ipv6 address

### DIFF
--- a/test/e2e/node/node.go
+++ b/test/e2e/node/node.go
@@ -52,7 +52,7 @@ func IPV6NetworkExists(client *testclient.ClientSet, timeout time.Duration) bool
 			continue
 		}
 		ip := net.ParseIP(address.Address)
-		if ip.To4() == nil {
+		if ip.To16() != nil {
 			return true
 		}
 	}

--- a/test/e2e/node/node.go
+++ b/test/e2e/node/node.go
@@ -7,6 +7,7 @@ import (
 
 	testclient "github.com/openshift/ingress-node-firewall/test/e2e/client"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -23,6 +24,9 @@ func IPV4NetworkExists(client *testclient.ClientSet, timeout time.Duration) bool
 	node := nodesList.Items[0]
 
 	for _, address := range node.Status.Addresses {
+		if address.Type != corev1.NodeInternalIP {
+			continue
+		}
 		ip := net.ParseIP(address.Address)
 		if ip.To4() != nil {
 			return true
@@ -44,6 +48,9 @@ func IPV6NetworkExists(client *testclient.ClientSet, timeout time.Duration) bool
 	node := nodesList.Items[0]
 
 	for _, address := range node.Status.Addresses {
+		if address.Type != corev1.NodeInternalIP {
+			continue
+		}
 		ip := net.ParseIP(address.Address)
 		if ip.To4() == nil {
 			return true


### PR DESCRIPTION
Signed-off-by: Martin Kennelly <mkennell@redhat.com>

Comment from @msherif1234 that wasn't addressed in #173 