### PR TITLE
E2E tests: add basic disruption tests

### DIFF
--- a/cmd/syslog/syslog.go
+++ b/cmd/syslog/syslog.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"gopkg.in/mcuadros/go-syslog.v2"
 )
@@ -21,12 +24,26 @@ func main() {
 	server.SetHandler(handler)
 
 	if err := server.ListenUnixgram(listenAddress); err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to listen to syslog unix socket %s, err %s", listenAddress, err)
 	}
 
 	if err := server.Boot(); err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to boot syslog server err %s", err)
 	}
+
+	// Unix sockets must be unlink()ed before being reused again.
+	// Handle common process-killing signals so we can gracefully shut down:
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, os.Interrupt, os.Kill, syscall.SIGTERM)
+	go func(c chan os.Signal) {
+		// Wait for a SIGINT or SIGKILL:
+		sig := <-c
+		log.Printf("Caught signal %s: shutting down.", sig)
+		// Stop listening (and unlink the socket if unix type):
+		_ = server.Kill()
+		_ = os.Remove(listenAddress)
+		os.Exit(0)
+	}(sigc)
 
 	go func(channel syslog.LogPartsChannel) {
 		for logParts := range channel {

--- a/controllers/ingressnodefirewallnodestate_controller.go
+++ b/controllers/ingressnodefirewallnodestate_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // IngressNodeFirewallNodeStateReconciler reconciles a IngressNodeFirewallNodeState object
@@ -37,6 +38,8 @@ type IngressNodeFirewallNodeStateReconciler struct {
 	Log       logr.Logger
 	Stats     *metrics.Statistics
 }
+
+var ingressNodeFirewallFinalizer = "ingressnodefirewall.openshift.io/finalizer"
 
 //+kubebuilder:rbac:groups=ingressnodefirewall.openshift.io,resources=ingressnodefirewallnodestates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ingressnodefirewall.openshift.io,namespace=ingress-node-firewall-system,resources=ingressnodefirewallnodestates,verbs=get;list;watch;create;update;patch;delete
@@ -62,15 +65,37 @@ func (r *IngressNodeFirewallNodeStateReconciler) Reconcile(ctx context.Context, 
 	nodeState := &infv1alpha1.IngressNodeFirewallNodeState{}
 	err := r.Get(ctx, req.NamespacedName, nodeState)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			return r.reconcileResource(ctx, req, nodeState, true)
+		// Expect not to find node state that has been deleted. Handling of deletion should have previously occurred,
+		// therefore we only ignore errors with reason 'StatusReasonNotFound'.
+		if !apierrors.IsNotFound(err) {
+			r.Log.Error(err, "unable to get IngressNodeFirewallNodeState")
+			return ctrl.Result{}, err
 		}
-		// Error reading the object - requeue the request.
-		r.Log.Error(err, "Failed to get IngressNodeFirewallNodeState")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// check if node state is being deleted
+	if isNodeStateDeletionInProgress(nodeState) {
+		if controllerutil.ContainsFinalizer(nodeState, ingressNodeFirewallFinalizer) {
+			if result, err := r.reconcileResource(ctx, req, nodeState, true); err != nil {
+				r.Log.Error(err, "failed to reconcile IngressNodeFirewallNodeState that is being deleted")
+				return result, err
+			}
+			controllerutil.RemoveFinalizer(nodeState, ingressNodeFirewallFinalizer)
+			if err = r.Update(ctx, nodeState); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		// stop reconciliation as node state is being deleted
+		return ctrl.Result{}, nil
+	} else {
+		// ensure node state contains finalizer if object is not being deleted
+		if !controllerutil.ContainsFinalizer(nodeState, ingressNodeFirewallFinalizer) {
+			controllerutil.AddFinalizer(nodeState, ingressNodeFirewallFinalizer)
+			if err = r.Update(ctx, nodeState); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 	}
 
 	r.Log.Info("Reconciling resource and programming bpf", "name", nodeState.Name, "namespace", nodeState.Namespace)
@@ -95,4 +120,8 @@ func (r *IngressNodeFirewallNodeStateReconciler) reconcileResource(
 		return ctrl.Result{}, errors.Wrapf(err, "FailedToSyncIngressNodeFirewallResources")
 	}
 	return ctrl.Result{}, nil
+}
+
+func isNodeStateDeletionInProgress(nodeState *infv1alpha1.IngressNodeFirewallNodeState) bool {
+	return !nodeState.ObjectMeta.DeletionTimestamp.IsZero()
 }

--- a/pkg/ebpf/ingress_node_firewall_loader.go
+++ b/pkg/ebpf/ingress_node_firewall_loader.go
@@ -376,6 +376,15 @@ func (infc *IngNodeFwController) loadPinnedLinks() error {
 	return nil
 }
 
+func (infc *IngNodeFwController) GetPinnedLinkNames() []string {
+	linkNames := make([]string, 0, len(infc.links))
+
+	for linkName, _ := range infc.links {
+		linkNames = append(linkNames, linkName)
+	}
+	return linkNames
+}
+
 // cleanup will delete an interface's eBPF objects.
 func (infc *IngNodeFwController) cleanup(ifName string) error {
 	l, ok := infc.links[ifName]

--- a/pkg/ebpfsyncer/ebpfsyncer.go
+++ b/pkg/ebpfsyncer/ebpfsyncer.go
@@ -87,6 +87,12 @@ func (e *ebpfSingleton) SyncInterfaceIngressRules(
 		return err
 	}
 
+	// Ensure IngNodeFwController's pinned links and our managed interfaces align
+	// TODO: refactor to not have managed interfaces names from two sources
+	for _, linkName := range e.c.GetPinnedLinkNames() {
+		e.managedInterfaces[linkName] = struct{}{}
+	}
+
 	// For delete operations, detach all interfaces and run a cleanup, set managed interfaces and the
 	// manager to empty / nil values, then return.
 	if isDelete {

--- a/test/e2e/daemonset/daemonset.go
+++ b/test/e2e/daemonset/daemonset.go
@@ -15,11 +15,33 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-func WaitForDaemonSetReady(client *testclient.ClientSet, ds *appsv1.DaemonSet, namespace, name string, retryInterval, timeout time.Duration) error {
+func GetDaemonSet(client *testclient.ClientSet, namespace, name string, timeout time.Duration) (*appsv1.DaemonSet, error) {
+	var daemonSet appsv1.DaemonSet
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &daemonSet)
+	return &daemonSet, err
+}
+
+func GetDaemonSetWithRetry(client *testclient.ClientSet, namespace, name string, retryInterval, timeout time.Duration) (*appsv1.DaemonSet, error) {
+	var daemonSet *appsv1.DaemonSet
+	err := wait.PollImmediate(retryInterval, timeout, func() (done bool, err error) {
+		if daemonSet, err = GetDaemonSet(client, namespace, name, timeout); err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, err
+	})
+	return daemonSet, err
+}
+
+func WaitForDaemonSetReady(client *testclient.ClientSet, ds *appsv1.DaemonSet, retryInterval, timeout time.Duration) error {
 	err := wait.PollImmediate(retryInterval, timeout, func() (done bool, err error) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
-		err = client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, ds)
+		err = client.Get(ctx, types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, ds)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil
@@ -33,7 +55,7 @@ func WaitForDaemonSetReady(client *testclient.ClientSet, ds *appsv1.DaemonSet, n
 		}
 	})
 	if err != nil {
-		return fmt.Errorf("failed to wait for daemonset %s in namespace %s to be ready: %v", ds.Name, namespace, err)
+		return fmt.Errorf("failed to wait for daemonset %s in namespace %s to be ready: %v", ds.Name, ds.Namespace, err)
 	}
 
 	return nil

--- a/test/e2e/deployment/deployment.go
+++ b/test/e2e/deployment/deployment.go
@@ -1,0 +1,64 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	testclient "github.com/openshift/ingress-node-firewall/test/e2e/client"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func GetDeployment(client *testclient.ClientSet, namespace, name string, timeout time.Duration) (*appsv1.Deployment, error) {
+	var deployment appsv1.Deployment
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &deployment)
+	return &deployment, err
+}
+
+func GetDeploymentWithRetry(client *testclient.ClientSet, namespace, name string, retryInterval, timeout time.Duration) (*appsv1.Deployment, error) {
+	var deployment *appsv1.Deployment
+	err := wait.PollImmediate(retryInterval, timeout, func() (done bool, err error) {
+		if deployment, err = GetDeployment(client, namespace, name, timeout); err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+
+	return deployment, err
+}
+
+func WaitForDeploymentSetReady(client *testclient.ClientSet, deployment *appsv1.Deployment, retryInterval,
+	timeout time.Duration) error {
+
+	err := wait.PollImmediate(retryInterval, timeout, func() (done bool, err error) {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		err = client.Get(ctx, types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, deployment)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if *deployment.Spec.Replicas == deployment.Status.ReadyReplicas {
+			return true, nil
+		} else {
+			return false, nil
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait for deployment %s in namespace %s to be ready: %v", deployment.Name,
+			deployment.Namespace, err)
+	}
+
+	return nil
+}

--- a/test/e2e/ingress-node-firewall/ingress-node-firewall.go
+++ b/test/e2e/ingress-node-firewall/ingress-node-firewall.go
@@ -76,6 +76,16 @@ func EnsureIngressNodeFirewallConfigExists(client *testclient.ClientSet, config 
 	return err
 }
 
+func GetIngressNodeFirewallConfigs(client *testclient.ClientSet, timeout time.Duration) ([]ingressnodefwv1alpha1.IngressNodeFirewallConfig, error) {
+	var infcList ingressnodefwv1alpha1.IngressNodeFirewallConfigList
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := client.List(ctx, &infcList); err != nil {
+		return nil, err
+	}
+	return infcList.Items, nil
+}
+
 func CreateIngressNodeFirewall(client *testclient.ClientSet, inf *ingressnodefwv1alpha1.IngressNodeFirewall,
 	timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/test/e2e/pods/pods.go
+++ b/test/e2e/pods/pods.go
@@ -53,8 +53,8 @@ func EnsureDeleted(client *testclient.ClientSet, pod *corev1.Pod, timeout time.D
 	return nil
 }
 
-func EnsureDeletedWithLabel(client *testclient.ClientSet, ns, label string, timeout time.Duration) error {
-	podList, err := client.Pods(ns).List(context.TODO(), metav1.ListOptions{
+func EnsureDeletedWithLabel(client *testclient.ClientSet, namespace, label string, timeout time.Duration) error {
+	podList, err := client.Pods(namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: label,
 	})
 	if err != nil {
@@ -66,6 +66,23 @@ func EnsureDeletedWithLabel(client *testclient.ClientSet, ns, label string, time
 		}
 	}
 	return nil
+}
+
+func GetPodWithLabelRestartCount(client *testclient.ClientSet, namespace, label string, timeout time.Duration) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	pods, err := client.Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: label})
+	if err != nil {
+		return 0, err
+	}
+	var count int
+	for _, pod := range pods.Items {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			count += int(containerStatus.RestartCount)
+		}
+	}
+	return count, nil
 }
 
 func GetIPV4(ips []corev1.PodIP) string {


### PR DESCRIPTION
Signed-off-by: Martin Kennelly <mkennell@redhat.com>

Expecting test named `IngressNodeFirewall policy is configurable after daemon deletion` to fail - seen with KinD and bare metal server.
INF policy configuration isn't working after daemon deletion.

Executed go mod tidy + go mod vendor
Executed make lint and its clean
