### PR TITLE
Fix #222 after pod restart bpf maps are gone

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -23,22 +23,6 @@ spec:
       tolerations:
         - operator: Exists
       priorityClassName: "system-node-critical"
-      initContainers:
-        - name: mount-bpffs
-          image: '{{.Image}}'
-          command: ['mount', 'bpffs', '/sys/fs/bpf', '-t', 'bpf']
-          securityContext:
-            privileged: true
-            runAsUser: 0
-            capabilities:
-              add:
-                - CAP_BPF
-                - CAP_NET_ADMIN
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-              mountPropagation: Bidirectional
       containers:
         - name: daemon
           image: '{{.Image}}'

--- a/controllers/ingressnodefirewallconfig_controller_test.go
+++ b/controllers/ingressnodefirewallconfig_controller_test.go
@@ -24,9 +24,6 @@ var _ = Describe("Ingress nodefirewall config Controller", func() {
 					Namespace: IngressNodeFwConfigTestNameSpace,
 				},
 			}
-			daemonInitContainers := map[string]string{
-				"mount-bpffs": "test-daemon:latest",
-			}
 			daemonContainers := map[string]string{
 				"daemon":          "test-daemon:latest",
 				"events":          "test-daemon:latest",
@@ -48,12 +45,6 @@ var _ = Describe("Ingress nodefirewall config Controller", func() {
 			for _, c := range daemonSet.Spec.Template.Spec.Containers {
 				image, ok := daemonContainers[c.Name]
 				Expect(ok).To(BeTrue(), fmt.Sprintf("container %s not found in %s", c.Name, daemonContainers))
-				Expect(c.Image).To(Equal(image))
-			}
-			Expect(daemonSet.Spec.Template.Spec.InitContainers).To(HaveLen(len(daemonInitContainers)))
-			for _, c := range daemonSet.Spec.Template.Spec.InitContainers {
-				image, ok := daemonInitContainers[c.Name]
-				Expect(ok).To(BeTrue(), fmt.Sprintf("init container %s not found in %s", c.Name, daemonInitContainers))
 				Expect(c.Image).To(Equal(image))
 			}
 

--- a/hack/kind-cluster.sh
+++ b/hack/kind-cluster.sh
@@ -40,7 +40,15 @@ nodes:
         extraArgs:
             v: "5"
 - role: worker
+  extraMounts:
+      - hostPath: /sys/fs/bpf
+        containerPath: /sys/fs/bpf
+        propagation: Bidirectional
 - role: worker
+  extraMounts:
+      - hostPath: /sys/fs/bpf
+        containerPath: /sys/fs/bpf
+        propagation: Bidirectional
 EOF
 }
 

--- a/pkg/ebpfsyncer/ebpfsyncer.go
+++ b/pkg/ebpfsyncer/ebpfsyncer.go
@@ -103,11 +103,9 @@ func (e *ebpfSingleton) SyncInterfaceIngressRules(
 		return err
 	}
 
-	if len(e.managedInterfaces) != 0 {
-		// Load IngressNodeFirewall Rules (this is idempotent and will add new rules and purge rules that shouldn't exist).
-		if err := e.loadIngressNodeFirewallRules(ifaceIngressRules); err != nil {
-			return err
-		}
+	// Load IngressNodeFirewall Rules (this is idempotent and will add new rules and purge rules that shouldn't exist).
+	if err := e.loadIngressNodeFirewallRules(ifaceIngressRules); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
We should mounted bpffs at the host not inside
the pod to be able to presist bpf maps
    
Fix for OCP will be done via
https://github.com/openshift/machine-config-operator/pull/3386

Note: OCP CI will fail till we have `MCO` PR fixed 
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
