### PR TITLE
OCPBUGS-2934: unlink events unix socket during shutdown

### DIFF
--- a/cmd/syslog/syslog.go
+++ b/cmd/syslog/syslog.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"gopkg.in/mcuadros/go-syslog.v2"
 )
@@ -20,13 +23,40 @@ func main() {
 	server.SetFormat(syslog.RFC3164)
 	server.SetHandler(handler)
 
-	if err := server.ListenUnixgram(listenAddress); err != nil {
-		log.Fatal(err)
+	// check if syslog unix socket is already there then delete it.
+	if _, err := os.Stat(listenAddress); err == nil {
+		if err := os.Remove(listenAddress); err != nil {
+			log.Fatalf("error removing syslog socket %s: %s", listenAddress, err)
+		}
 	}
 
-	if err := server.Boot(); err != nil {
-		log.Fatal(err)
+	if err := server.ListenUnixgram(listenAddress); err != nil {
+		log.Fatalf("failed to listen to syslog unix socket %s: %s", listenAddress, err)
 	}
+
+	defer func() {
+		if err := os.Remove(listenAddress); err != nil {
+			log.Fatalf("error removing syslog socket %s: %s", listenAddress, err)
+		}
+	}()
+
+	if err := server.Boot(); err != nil {
+		log.Fatalf("failed to boot syslog server: %s", err)
+	}
+
+	// Unix sockets must be unlink()ed before being reused again.
+	// Handle common process-killing signals so we can gracefully shut down:
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, os.Interrupt, syscall.SIGTERM)
+	go func(c chan os.Signal) {
+		// Wait for a SIGINT or SIGKILL:
+		sig := <-c
+		log.Printf("Caught signal %s: shutting down.\n", sig)
+		// Stop listening (and unlink the socket if unix type):
+		if err := server.Kill(); err != nil {
+			log.Fatalf("failed to close server connections: %s", err)
+		}
+	}(sigc)
 
 	go func(channel syslog.LogPartsChannel) {
 		for logParts := range channel {


### PR DESCRIPTION
to reuse unix socket we have to unlink before attempting to reuse
when the events container restarts

To repro on kind we can restart the node container for example
```sh
 docker restart kind-worker
```

from the event container
```
 k logs -n ingress-node-firewall-system   ingress-node-firewall-daemon-pkfrd  -c events --previous
2022/10/28 21:19:59 Caught signal terminated: shutting down.
```
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>


