### PR TITLE
SDN-3721: migrate to rhel9 base images

### DIFF
--- a/Dockerfile.daemon.openshift
+++ b/Dockerfile.daemon.openshift
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.14 AS builder
 
 WORKDIR /go/src/github.com/openshift/ingress-node-firewall
 COPY . .
 RUN ./hack/build-daemon.sh
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.14
 COPY --from=builder /go/src/github.com/openshift/ingress-node-firewall/bin/daemon /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ingress-node-firewall/bin/syslog /usr/bin/
 CMD ["/usr/bin/daemon"]

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.14 AS builder
 
 WORKDIR /workspace
 
@@ -18,7 +18,7 @@ COPY bindata/manifests/ bindata/manifests/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -mod=vendor -o manager main.go
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.14
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/bindata/manifests /bindata/manifests

--- a/hack/build-daemon.sh
+++ b/hack/build-daemon.sh
@@ -12,7 +12,7 @@ LDFLAGS=${LDFLAGS:-}
 # Set cross compilation flags and version override.
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
-CGO_ENABLED=${CGO_ENABLED:-1}
+CGO_ENABLED=${CGO_ENABLED:-0}
 if [ -z ${VERSION_OVERRIDE+a} ]; then
     echo "Using version from git..."
     VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)


### PR DESCRIPTION
rhel9 container images causing the following runtime issue causing daemonset crashloop
```shell
/usr/bin/daemon: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /usr/bin/daemon)
/usr/bin/daemon: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /usr/bin/daemon)
```
Signed-off-by: msherif1234 <mmahmoud@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/openshift/ingress-node-firewall/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
