### PR TITLE
Fix #207 to fix TLS errors we need to annotate the CRD

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ingress-node-firewall
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.0-ocp
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/ingress-node-firewall-webhook-service_v1_service.yaml
+++ b/bundle/manifests/ingress-node-firewall-webhook-service_v1_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: webhook-server-cert
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   creationTimestamp: null
   name: ingress-node-firewall-webhook-service
 spec:

--- a/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
+++ b/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
@@ -88,7 +88,7 @@ metadata:
     createdAt: "2022-10-28 00:00:00"
     olm.skipRange: '>=4.11.0 <4.13.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
-    operators.operatorframework.io/builder: operator-sdk-v1.22.0
+    operators.operatorframework.io/builder: operator-sdk-v1.25.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/ingress-node-firewall
     support: Red Hat

--- a/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
     controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: ingressnodefirewalls.ingressnodefirewall.openshift.io

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ingress-node-firewall
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.0-ocp
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -17,7 +17,7 @@ patchesStrategicMerge:
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_ingressnodefirewalls.yaml
+#- patches/cainjection_in_ingressnodefirewalls.yaml
 #- patches/cainjection_in_ingressnodefirewallnodestates.yaml
 #- patches/cainjection_in_ingressnodefirewallconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -2,7 +2,7 @@
 # used to generate the 'manifests/' directory in a bundle.
 resources:
 - bases/ingress-node-firewall.clusterserviceversion.yaml
-- ../openshift
+- ../openshift-olm
 - ../samples
 - ../scorecard
 

--- a/config/openshift-olm/namespace.yaml
+++ b/config/openshift-olm/namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  annotations:
+    openshift.io/node-selector: ""
+    openshift.io/description: "Openshift ingress node firewall components"
+    workload.openshift.io/allowed: "management"
+  name: openshift-ingress-node-firewall
+

--- a/config/openshift-olm/patch.yaml
+++ b/config/openshift-olm/patch.yaml
@@ -35,17 +35,3 @@ metadata:
   annotations:
     # functionality only works on openshift
     service.beta.openshift.io/serving-cert-secret-name: ingress-node-firewall-daemon-metrics-certs
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
-  name: ingressnodefirewalls.ingressnodefirewall.openshift.io
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
-  name: ingressnodefirewallconfigs.ingressnodefirewall.openshift.io

--- a/config/openshift-olm/rbac.yaml
+++ b/config/openshift-olm/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: privileged-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: ingress-node-firewall-daemon
+  namespace: openshift-ingress-node-firewall

--- a/manifests/stable/ingress-node-firewall-webhook-service_v1_service.yaml
+++ b/manifests/stable/ingress-node-firewall-webhook-service_v1_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: webhook-server-cert
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   creationTimestamp: null
   name: ingress-node-firewall-webhook-service
 spec:

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -88,7 +88,7 @@ metadata:
     createdAt: "2022-10-28 00:00:00"
     olm.skipRange: '>=4.11.0 <4.13.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
-    operators.operatorframework.io/builder: operator-sdk-v1.22.0
+    operators.operatorframework.io/builder: operator-sdk-v1.25.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/ingress-node-firewall
     support: Red Hat

--- a/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
     controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: ingressnodefirewalls.ingressnodefirewall.openshift.io


### PR DESCRIPTION
- we can't use cert-mgr when deploy OLM operator on OCP
- we need to annotate CRD only for raw manifest deploy not for olm bundle deploy
Signed-off-by: msherif1234 <mmahmoud@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/openshift/ingress-node-firewall/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
