### PR TITLE
OCPBUGS-11888: handle daemonSet pods restart

### DIFF
--- a/controllers/ingressnodefirewallnodestate_controller.go
+++ b/controllers/ingressnodefirewallnodestate_controller.go
@@ -66,7 +66,7 @@ func (r *IngressNodeFirewallNodeStateReconciler) Reconcile(ctx context.Context, 
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
-			return r.reconcileResource(ctx, req, nodeState, true)
+			return r.reconcileResource(ctx, nodeState, true)
 		}
 		// Error reading the object - requeue the request.
 		r.Log.Error(err, "Failed to get IngressNodeFirewallNodeState")
@@ -74,7 +74,7 @@ func (r *IngressNodeFirewallNodeStateReconciler) Reconcile(ctx context.Context, 
 	}
 
 	r.Log.Info("Reconciling resource and programming bpf", "name", nodeState.Name, "namespace", nodeState.Namespace)
-	return r.reconcileResource(ctx, req, nodeState, false)
+	return r.reconcileResource(ctx, nodeState, false)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -90,7 +90,7 @@ var mock ebpfsyncer.EbpfSyncer = nil
 // reconcileResource reconciles the resource by getting the EbpfDaemon singleton's SyncInterfaceIngressRules method.
 // For mock tests, var mock can be overwritten.
 func (r *IngressNodeFirewallNodeStateReconciler) reconcileResource(
-	ctx context.Context, req ctrl.Request, instance *infv1alpha1.IngressNodeFirewallNodeState, isDelete bool) (ctrl.Result, error) {
+	ctx context.Context, instance *infv1alpha1.IngressNodeFirewallNodeState, isDelete bool) (ctrl.Result, error) {
 	if err := ebpfsyncer.GetEbpfSyncer(ctx, r.Log, r.Stats, mock).SyncInterfaceIngressRules(instance.Spec.InterfaceIngressRules, isDelete); err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "FailedToSyncIngressNodeFirewallResources")
 	}


### PR DESCRIPTION
when delete daemonSet or daemon pods manually
pods will get recreated but the interface will
have older xdp attached to it

**- What this PR does and why is it needed**
fix an issue where we have stale XDP attached to interface(s) when daemonset restarts


**- How to verify it**
- bring up OCP cluster
- configure sctp and deploy sctp client and server pods
```shell
 oc get pods -o wide
NAME         READY   STATUS    RESTARTS   AGE   IP            NODE                                       NOMINATED NODE   READINESS GATES
sctpclient   1/1     Running   0          17s   10.128.2.24   ci-ln-6rzv9ik-72292-ctfxk-worker-c-ls2sf   <none>           <none>
sctpserver   1/1     Running   0          17s   10.129.2.26   ci-ln-6rzv9ik-72292-ctfxk-worker-b-n2x9r   <none>           <none>
```
- configure INFW and add rule to drop sctp traffic
```shell
$ oc get ingressnodefirewalls.ingressnodefirewall.openshift.io ingressnodefirewall-sctp -o yaml
apiVersion: ingressnodefirewall.openshift.io/v1alpha1
kind: IngressNodeFirewall
metadata:
  creationTimestamp: "2023-05-18T16:12:05Z"
  generation: 1
  name: ingressnodefirewall-sctp
  resourceVersion: "43804"
  uid: c6136909-60fe-4d73-ad46-68468399894b
spec:
  ingress:
  - rules:
    - action: Deny
      order: 10
      protocolConfig:
        protocol: SCTP
        sctp:
          ports: 30102-33000
    sourceCIDRs:
    - 10.128.2.24/24
  interfaces:
  - genev_sys_6081
  nodeSelector:
    matchLabels:
      node-role.kubernetes.io/worker: ""
status:
  syncStatus: Synchronized
```
- run ncat traffic make sure traffic is blocked and event is generated
```shell
$ oc rsh sctpserver
sh-4.2# ncat -l 30102 --sctp 

$ oc rsh sctpclient
sh-4.2# nc -v 10.129.2.26 30102 --sctp
Ncat: Version 7.50 ( https://nmap.org/ncat )
Ncat: Connection timed out.

$ oc logs -n openshift-ingress-node-firewall ingress-node-firewall-daemon-lvq5x -c events --follow
2023-05-18 16:13:02 +0000 UTC ci-ln-6rzv9ik-72292-ctfxk-worker-b-n2x9r ruleId 10 action Drop len 82 if genev_sys_6081
2023-05-18 16:13:02 +0000 UTC ci-ln-6rzv9ik-72292-ctfxk-worker-b-n2x9r 	ipv4 src addr 10.128.2.24 dst addr 10.129.2.26
2023-05-18 16:13:02 +0000 UTC ci-ln-6rzv9ik-72292-ctfxk-worker-b-n2x9r 	sctp srcPort 45827 dstPort 30102
```
- delete ingress-node-firewall daemon set 
```shell
oc delete ds -n openshift-ingress-node-firewall  ingress-node-firewall-daemon
```
- run traffic again make sure its blocked and events are generated
```shell
$ oc logs -n openshift-ingress-node-firewall ingress-node-firewall-daemon-wwh6b -c events --follow
2023-05-18 16:14:20 +0000 UTC ci-ln-6rzv9ik-72292-ctfxk-worker-b-n2x9r ruleId 10 action Drop len 82 if genev_sys_6081
2023-05-18 16:14:20 +0000 UTC ci-ln-6rzv9ik-72292-ctfxk-worker-b-n2x9r 	ipv4 src addr 10.128.2.24 dst addr 10.129.2.26
2023-05-18 16:14:20 +0000 UTC ci-ln-6rzv9ik-72292-ctfxk-worker-b-n2x9r 	sctp srcPort 36697 dstPort 30102
```