### PR TITLE
SDN-3979: E2E extend testing by including disruption test cases

### DIFF
--- a/controllers/ingressnodefirewallnodestate_controller.go
+++ b/controllers/ingressnodefirewallnodestate_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // IngressNodeFirewallNodeStateReconciler reconciles a IngressNodeFirewallNodeState object
@@ -37,6 +38,8 @@ type IngressNodeFirewallNodeStateReconciler struct {
 	Log       logr.Logger
 	Stats     *metrics.Statistics
 }
+
+var ingressNodeFirewallFinalizer = "ingressnodefirewall.openshift.io/finalizer"
 
 //+kubebuilder:rbac:groups=ingressnodefirewall.openshift.io,resources=ingressnodefirewallnodestates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ingressnodefirewall.openshift.io,namespace=ingress-node-firewall-system,resources=ingressnodefirewallnodestates,verbs=get;list;watch;create;update;patch;delete
@@ -62,15 +65,37 @@ func (r *IngressNodeFirewallNodeStateReconciler) Reconcile(ctx context.Context, 
 	nodeState := &infv1alpha1.IngressNodeFirewallNodeState{}
 	err := r.Get(ctx, req.NamespacedName, nodeState)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			return r.reconcileResource(ctx, nodeState, true)
+		// Expect not to find node state that has been deleted. Handling of deletion should have previously occurred,
+		// therefore we only ignore errors with reason 'StatusReasonNotFound'.
+		if !apierrors.IsNotFound(err) {
+			r.Log.Error(err, "unable to get IngressNodeFirewallNodeState")
+			return ctrl.Result{}, err
 		}
-		// Error reading the object - requeue the request.
-		r.Log.Error(err, "Failed to get IngressNodeFirewallNodeState")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// check if node state is being deleted
+	if isNodeStateDeletionInProgress(nodeState) {
+		if controllerutil.ContainsFinalizer(nodeState, ingressNodeFirewallFinalizer) {
+			if result, err := r.reconcileResource(ctx, nodeState, true); err != nil {
+				r.Log.Error(err, "failed to reconcile IngressNodeFirewallNodeState that is being deleted")
+				return result, err
+			}
+			controllerutil.RemoveFinalizer(nodeState, ingressNodeFirewallFinalizer)
+			if err = r.Update(ctx, nodeState); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		// stop reconciliation as node state is being deleted
+		return ctrl.Result{}, nil
+	} else {
+		// ensure node state contains finalizer if object is not being deleted
+		if !controllerutil.ContainsFinalizer(nodeState, ingressNodeFirewallFinalizer) {
+			controllerutil.AddFinalizer(nodeState, ingressNodeFirewallFinalizer)
+			if err = r.Update(ctx, nodeState); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 	}
 
 	r.Log.Info("Reconciling resource and programming bpf", "name", nodeState.Name, "namespace", nodeState.Namespace)
@@ -95,4 +120,8 @@ func (r *IngressNodeFirewallNodeStateReconciler) reconcileResource(
 		return ctrl.Result{}, errors.Wrapf(err, "FailedToSyncIngressNodeFirewallResources")
 	}
 	return ctrl.Result{}, nil
+}
+
+func isNodeStateDeletionInProgress(nodeState *infv1alpha1.IngressNodeFirewallNodeState) bool {
+	return !nodeState.ObjectMeta.DeletionTimestamp.IsZero()
 }

--- a/test/e2e/daemonset/daemonset.go
+++ b/test/e2e/daemonset/daemonset.go
@@ -15,11 +15,33 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-func WaitForDaemonSetReady(client *testclient.ClientSet, ds *appsv1.DaemonSet, namespace, name string, retryInterval, timeout time.Duration) error {
-	err := wait.PollImmediate(retryInterval, timeout, func() (done bool, err error) {
+func GetDaemonSet(client *testclient.ClientSet, namespace, name string, timeout time.Duration) (*appsv1.DaemonSet, error) {
+	var daemonSet appsv1.DaemonSet
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &daemonSet)
+	return &daemonSet, err
+}
+
+func GetDaemonSetWithRetry(client *testclient.ClientSet, namespace, name string, retryInterval, timeout time.Duration) (*appsv1.DaemonSet, error) {
+	var daemonSet *appsv1.DaemonSet
+	err := wait.PollUntilContextTimeout(context.Background(), retryInterval, timeout, true, func(ctx context.Context) (done bool, err error) {
+		if daemonSet, err = GetDaemonSet(client, namespace, name, timeout); err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, err
+	})
+	return daemonSet, err
+}
+
+func WaitForDaemonSetReady(client *testclient.ClientSet, ds *appsv1.DaemonSet, retryInterval, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(context.Background(), retryInterval, timeout, true, func(ctx context.Context) (done bool, err error) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
-		err = client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, ds)
+		err = client.Get(ctx, types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, ds)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil
@@ -33,7 +55,7 @@ func WaitForDaemonSetReady(client *testclient.ClientSet, ds *appsv1.DaemonSet, n
 		}
 	})
 	if err != nil {
-		return fmt.Errorf("failed to wait for daemonset %s in namespace %s to be ready: %v", ds.Name, namespace, err)
+		return fmt.Errorf("failed to wait for daemonset %s in namespace %s to be ready: %v", ds.Name, ds.Namespace, err)
 	}
 
 	return nil
@@ -41,7 +63,7 @@ func WaitForDaemonSetReady(client *testclient.ClientSet, ds *appsv1.DaemonSet, n
 
 func GetDaemonSetOnNode(client *testclient.ClientSet, namespace, nodeName string) (*corev1.Pod, error) {
 	var podList *corev1.PodList
-	err := wait.PollImmediate(1*time.Second, 10*time.Second, func() (done bool, err error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		podList, err = client.Pods(namespace).List(context.TODO(), metav1.ListOptions{
 			LabelSelector: "app=ingress-node-firewall-daemon",
 			FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),

--- a/test/e2e/deployment/deployment.go
+++ b/test/e2e/deployment/deployment.go
@@ -1,0 +1,64 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	testclient "github.com/openshift/ingress-node-firewall/test/e2e/client"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func GetDeployment(client *testclient.ClientSet, namespace, name string, timeout time.Duration) (*appsv1.Deployment, error) {
+	var deployment appsv1.Deployment
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &deployment)
+	return &deployment, err
+}
+
+func GetDeploymentWithRetry(client *testclient.ClientSet, namespace, name string, retryInterval, timeout time.Duration) (*appsv1.Deployment, error) {
+	var deployment *appsv1.Deployment
+	err := wait.PollUntilContextTimeout(context.Background(), retryInterval, timeout, true, func(ctx context.Context) (done bool, err error) {
+		if deployment, err = GetDeployment(client, namespace, name, timeout); err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+
+	return deployment, err
+}
+
+func WaitForDeploymentSetReady(client *testclient.ClientSet, deployment *appsv1.Deployment, retryInterval,
+	timeout time.Duration) error {
+
+	err := wait.PollUntilContextTimeout(context.Background(), retryInterval, timeout, true, func(ctx context.Context) (done bool, err error) {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		err = client.Get(ctx, types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, deployment)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if *deployment.Spec.Replicas == deployment.Status.ReadyReplicas {
+			return true, nil
+		} else {
+			return false, nil
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait for deployment %s in namespace %s to be ready: %v", deployment.Name,
+			deployment.Namespace, err)
+	}
+
+	return nil
+}

--- a/test/e2e/ingress-node-firewall/ingress-node-firewall.go
+++ b/test/e2e/ingress-node-firewall/ingress-node-firewall.go
@@ -77,6 +77,16 @@ func EnsureIngressNodeFirewallConfigExists(client *testclient.ClientSet, config 
 	return err
 }
 
+func GetIngressNodeFirewallConfigs(client *testclient.ClientSet, timeout time.Duration) ([]ingressnodefwv1alpha1.IngressNodeFirewallConfig, error) {
+	var infcList ingressnodefwv1alpha1.IngressNodeFirewallConfigList
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := client.List(ctx, &infcList); err != nil {
+		return nil, err
+	}
+	return infcList.Items, nil
+}
+
 func CreateIngressNodeFirewall(client *testclient.ClientSet, inf *ingressnodefwv1alpha1.IngressNodeFirewall,
 	timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/test/e2e/namespaces/namespaces.go
+++ b/test/e2e/namespaces/namespaces.go
@@ -19,8 +19,8 @@ import (
 
 // WaitForDeletion waits until the namespace will be removed from the cluster
 func WaitForDeletion(cs *testclient.ClientSet, nsName string, timeout time.Duration) error {
-	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-		_, err := cs.Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
+	return wait.PollUntilContextTimeout(context.Background(), time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
+		_, err = cs.Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return true, nil
 		}

--- a/test/e2e/pods/pods.go
+++ b/test/e2e/pods/pods.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/utils/pointer"
 )
 
 func EnsureRunning(client *testclient.ClientSet, pod *corev1.Pod, namespace string,
@@ -23,7 +24,8 @@ func EnsureRunning(client *testclient.ClientSet, pod *corev1.Pod, namespace stri
 			return nil, err
 		}
 	}
-	err = wait.PollImmediate(retryInterval, timeout, func() (done bool, err error) {
+
+	err = wait.PollUntilContextTimeout(context.Background(), retryInterval, timeout, true, func(ctx context.Context) (done bool, err error) {
 		testPod, err = client.Pods(namespace).Get(context.Background(), created.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -36,17 +38,22 @@ func EnsureRunning(client *testclient.ClientSet, pod *corev1.Pod, namespace stri
 	return testPod, err
 }
 
-func EnsureDeleted(client *testclient.ClientSet, pod *corev1.Pod, timeout time.Duration) error {
-	err := client.Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+func EnsureDeleted(client *testclient.ClientSet, pod *corev1.Pod, retryInterval, timeout time.Duration) error {
+	err := client.Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
+		return err
 	}
+	err = wait.PollUntilContextTimeout(context.Background(), retryInterval, timeout, true, func(ctx context.Context) (done bool, err error) {
+		_, err = client.Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
 	return err
 }
 
-func EnsureDeletedWithLabel(client *testclient.ClientSet, ns, label string, timeout time.Duration) error {
+func EnsureDeletedWithLabel(client *testclient.ClientSet, ns, label string, retryInterval, timeout time.Duration) error {
 	podList, err := client.Pods(ns).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: label,
 	})
@@ -54,11 +61,25 @@ func EnsureDeletedWithLabel(client *testclient.ClientSet, ns, label string, time
 		return err
 	}
 	for _, pod := range podList.Items {
-		if err = EnsureDeleted(client, &pod, timeout); err != nil {
+		if err = EnsureDeleted(client, &pod, retryInterval, timeout); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func GetPodWithLabelRestartCount(client *testclient.ClientSet, namespace, label string, timeout time.Duration) (int, error) {
+	podList, err := client.Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: label})
+	if err != nil {
+		return 0, err
+	}
+	var count int
+	for _, pod := range podList.Items {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			count += int(containerStatus.RestartCount)
+		}
+	}
+	return count, nil
 }
 
 func GetIPV4(ips []corev1.PodIP) string {

--- a/test/e2e/transport/transport.go
+++ b/test/e2e/transport/transport.go
@@ -26,7 +26,7 @@ func GetAndEnsureRunningClient(client *testclient.ClientSet, podName, namespace 
 		return nil, nil, err
 	}
 	return pod, func() {
-		if err = pods.EnsureDeleted(client, pod, timeout); err != nil {
+		if err = pods.EnsureDeleted(client, pod, retryInterval, timeout); err != nil {
 			panic(err)
 		}
 	}, nil
@@ -85,7 +85,7 @@ func GetAndEnsureRunningTransportServer(client *testclient.ClientSet, podName, n
 		return nil, nil, err
 	}
 	return pod, func() {
-		if err = pods.EnsureDeleted(client, pod, timeout); err != nil {
+		if err = pods.EnsureDeleted(client, pod, retryInterval, timeout); err != nil {
 			panic(err)
 		}
 	}, nil


### PR DESCRIPTION
**- What this PR does and why is it needed**
this is follow up to PR #221 

test on kind cluster e2e pass
```shell
make test-e2e
JUnit report was created: /tmp/test_e2e_logs/e2e_junit.xml

Ran 22 of 22 Specs in 596.378 seconds
SUCCESS! -- 22 Passed | 0 Failed | 0 Pending | 0 Skipped

You're using deprecated Ginkgo functionality
```
