### PR TITLE
OCPBUGS-15828: Fix arm64 arch build images

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -16,7 +16,7 @@ COPY vendor/ vendor/
 COPY bindata/manifests/ bindata/manifests/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -mod=vendor -o manager main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -o manager main.go
 
 FROM registry.ci.openshift.org/ocp/4.14:base-rhel9
 WORKDIR /

--- a/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
+++ b/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
@@ -92,6 +92,10 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/ingress-node-firewall
     support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: ingress-node-firewall.v4.14.0
   namespace: placeholder
 spec:

--- a/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
+++ b/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
@@ -12,6 +12,10 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     repository: https://github.com/openshift/ingress-node-firewall
     support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: ingress-node-firewall.v0.0.0
   namespace: placeholder
 spec:

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -92,6 +92,10 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/ingress-node-firewall
     support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: ingress-node-firewall.v4.14.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
**- What this PR does and why is it needed**
Operator Dockerfile incorrectly hardcode arch to amd64

**- How to verify it**
bring up the operator on different arch

**- Description for the changelog**
fix hardcoded arch `amd64` in the operator dockerfile