### PR TITLE
OCPBUGS-22768:replace ingress node firewall container image to match ART

### DIFF
--- a/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
+++ b/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
@@ -84,7 +84,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/ingress-node-firewall-operator:4.12
+    containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
     createdAt: "2022-10-28 00:00:00"
     olm.skipRange: '>=4.11.0 <4.13.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall

--- a/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
+++ b/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/ingress-node-firewall-operator:4.12
+    containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
     createdAt: "2022-10-28 00:00:00"
     olm.skipRange: '>=4.11.0 <4.13.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -84,7 +84,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/ingress-node-firewall-operator:4.12
+    containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
     createdAt: "2022-10-28 00:00:00"
     olm.skipRange: '>=4.11.0 <4.13.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall


### PR DESCRIPTION
**- What this PR does and why is it needed**
update operator image in the csv OCP 4.12
