### PR TITLE
update golang to 1.21 since cilium latest requires go1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.21 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.daemon
+++ b/Dockerfile.daemon
@@ -1,4 +1,4 @@
-FROM golang:1.19 AS builder
+FROM golang:1.21 AS builder
 WORKDIR /go/src/github.com/openshift/ingress-node-firewall
 COPY . .
 


### PR DESCRIPTION
**- What this PR does and why is it needed**
update to go1.21 to be able to build upstream with latest cilium package

Error is
```sh

8.579 /go/pkg/mod/github.com/cilium/ebpf@v0.12.2/internal/sysenc/marshal.go:37:29: undefined: unsafe.StringData
8.579 note: module requires Go 1.20
22.46 # sigs.k8s.io/controller-runtime/pkg/cache
```