### PR TITLE
Update ingressnodefirewall_types.go

### DIFF
--- a/api/v1alpha1/ingressnodefirewall_types.go
+++ b/api/v1alpha1/ingressnodefirewall_types.go
@@ -155,12 +155,12 @@ type IngressNodeFirewallSpec struct {
 	// ingress is a list of ingress firewall policy rules.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems:=1
-	Ingress []IngressNodeFirewallRules `json:"ingress,omitempty"`
+	Ingress []IngressNodeFirewallRules `json:"ingress"`
 
 	// interfaces is a list of interfaces where the ingress firewall policy will be applied on.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems:=1
-	Interfaces []string `json:"interfaces,omitempty"`
+	Interfaces []string `json:"interfaces"`
 }
 
 type IngressNodeFirewallSyncStatus string


### PR DESCRIPTION
removed omitempty

Please make sure you've read and understood our contributing guidelines;
https://github.com/openshift/ingress-node-firewall/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes (https://github.com/openshift/ingress-node-firewall/issues/444)"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:


**- What this PR does and why is it needed**

omitempty was removed from the [ingress](https://github.com/openshift/ingress-node-firewall/blob/12da1395940541a4e9696cb599b72cd04ec4288d/api/v1alpha1/ingressnodefirewall_types.go#L153)  and [interfaces](https://github.com/openshift/ingress-node-firewall/blob/12da1395940541a4e9696cb599b72cd04ec4288d/api/v1alpha1/ingressnodefirewall_types.go#L163)

With these present as is, the operator allows 


**- Special notes for reviewers**

What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers

omitempty was removed from the [ingress](https://github.com/openshift/ingress-node-firewall/blob/12da1395940541a4e9696cb599b72cd04ec4288d/api/v1alpha1/ingressnodefirewall_types.go#L153)  and [interfaces](https://github.com/openshift/ingress-node-firewall/blob/12da1395940541a4e9696cb599b72cd04ec4288d/api/v1alpha1/ingressnodefirewall_types.go#L163)

**- How to verify it**

Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
My personal cluster is not available to you to verify but the change is simple to implement, build and test per the README here. 

Desired Result:

![Screenshot 2023-11-20 at 3 27 03 PM](https://github.com/openshift/ingress-node-firewall/assets/24865328/b8f68fdd-a3d3-436f-9bbe-b7d35ecce3ef)




**- Description for the changelog**

omitempty can take precedence over 	// +kubebuilder:validation:Required and // +kubebuilder:validation:MinItems:=1 , if this takes place (such as here) a manifest can be applied without the validation:MinItems:=1 taking place. While the IngressNodeFirewallState will show the status of failure taking place, this is confusing and inconvenient for admins/end users. This PR addresses this and prevents IngressNodeFirewall from being created with a known failing configuration. 

