### PR TITLE
prevent empty interfaces and configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# Build the manager binary
 FROM golang:1.21 as builder
 
 WORKDIR /workspace

--- a/api/v1alpha1/ingressnodefirewall_types.go
+++ b/api/v1alpha1/ingressnodefirewall_types.go
@@ -155,12 +155,12 @@ type IngressNodeFirewallSpec struct {
 	// ingress is a list of ingress firewall policy rules.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems:=1
-	Ingress []IngressNodeFirewallRules `json:"ingress,omitempty"`
+	Ingress []IngressNodeFirewallRules `json:"ingress"`
 
 	// interfaces is a list of interfaces where the ingress firewall policy will be applied on.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems:=1
-	Interfaces []string `json:"interfaces,omitempty"`
+	Interfaces []string `json:"interfaces"`
 }
 
 type IngressNodeFirewallSyncStatus string

--- a/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -273,6 +273,9 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+            required:
+            - ingress
+            - interfaces
             type: object
           status:
             description: IngressNodeFirewallStatus defines the observed state of IngressNodeFirewall.

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -264,6 +264,9 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+            required:
+            - ingress
+            - interfaces
             type: object
           status:
             description: IngressNodeFirewallStatus defines the observed state of IngressNodeFirewall.

--- a/controllers/ingressnodefirewall_controller_rules_test.go
+++ b/controllers/ingressnodefirewall_controller_rules_test.go
@@ -746,32 +746,6 @@ var _ = Describe("IngressNodeFirewall controller rules", func() {
 				},
 			},
 		},
-		"invalid interface name test": {
-			inSpecs: []infv1alpha1.IngressNodeFirewallSpec{
-				{
-					Ingress: []infv1alpha1.IngressNodeFirewallRules{
-						{
-							SourceCIDRs: []string{"10.0.0.0"},
-							FirewallProtocolRules: []infv1alpha1.IngressNodeFirewallProtocolRule{
-								{
-									Order: 10,
-									ProtocolConfig: infv1alpha1.IngressNodeProtocolConfig{
-										Protocol: infv1alpha1.ProtocolTypeTCP,
-										TCP: &infv1alpha1.IngressNodeFirewallProtoRule{
-											Ports: intstr.FromInt(80),
-										},
-									},
-									Action: infv1alpha1.IngressNodeFirewallAllow,
-								},
-							},
-						},
-					},
-					Interfaces: []string{},
-				},
-			},
-			outSpec:     infv1alpha1.IngressNodeFirewallNodeStateSpec{},
-			statusError: "Invalid interface name",
-		},
 	}
 
 	for s, tc := range tcs {

--- a/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -273,6 +273,9 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+            required:
+            - ingress
+            - interfaces
             type: object
           status:
             description: IngressNodeFirewallStatus defines the observed state of IngressNodeFirewall.

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -159,19 +159,23 @@ var _ = Describe("Interfaces", func() {
 
 	Context("ingress node firewall interfaces validation", func() {
 		It("interfaces config with valid interfaces name", func() {
+			initCIDRICMPRule(inf, ipv4CIDR, validOrder, false, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
 			configInterfaces(inf, []string{"eth0", "eth1"})
 			Expect(createIngressNodeFirewall(inf)).To(Succeed())
 			Expect(deleteIngressNodeFirewall(inf)).To(Succeed())
 		})
 		It("interfaces config with empty strings", func() {
+			initCIDRICMPRule(inf, ipv4CIDR, validOrder, false, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
 			configInterfaces(inf, []string{""})
 			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
 		})
 		It("interfaces config with too long interface name", func() {
+			initCIDRICMPRule(inf, ipv4CIDR, validOrder, false, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
 			configInterfaces(inf, []string{"abcd123459$%&ABDC44555555555"})
 			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
 		})
 		It("interfaces config with interface name starts with number", func() {
+			initCIDRICMPRule(inf, ipv4CIDR, validOrder, false, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
 			configInterfaces(inf, []string{"0th"})
 			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
 		})
@@ -184,6 +188,7 @@ var _ = Describe("Rules", func() {
 
 		BeforeEach(func() {
 			inf = getIngressNodeFirewall("rulesicmpv4")
+			configInterfaces(inf, []string{"eth0"})
 			initCIDRICMPRule(inf, ipv4CIDR, validOrder, false, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
 		})
 
@@ -216,6 +221,7 @@ var _ = Describe("Rules", func() {
 		BeforeEach(func() {
 			inf = getIngressNodeFirewall("rulesicmpv6")
 			initCIDRICMPRule(inf, ipv6CIDR, validOrder, true, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
+			configInterfaces(inf, []string{"eth0"})
 		})
 
 		It("allows valid rule", func() {
@@ -245,6 +251,7 @@ var _ = Describe("Rules", func() {
 		var inf *ingressnodefwv1alpha1.IngressNodeFirewall
 		BeforeEach(func() {
 			inf = getIngressNodeFirewall("rulestcp")
+			configInterfaces(inf, []string{"eth0"})
 		})
 
 		It("accepts rule with port range defined", func() {
@@ -289,6 +296,7 @@ var _ = Describe("Rules", func() {
 		var inf *ingressnodefwv1alpha1.IngressNodeFirewall
 		BeforeEach(func() {
 			inf = getIngressNodeFirewall("ruleudp")
+			configInterfaces(inf, []string{"eth0"})
 		})
 
 		It("accepts rule with port range defined", func() {
@@ -333,6 +341,7 @@ var _ = Describe("Rules", func() {
 		var inf *ingressnodefwv1alpha1.IngressNodeFirewall
 		BeforeEach(func() {
 			inf = getIngressNodeFirewall("rulessctp")
+			configInterfaces(inf, []string{"eth0"})
 		})
 
 		It("accepts rule with port range defined", func() {
@@ -379,6 +388,7 @@ var _ = Describe("Rules", func() {
 		BeforeEach(func() {
 			inf = getIngressNodeFirewall("meta")
 			initCIDRTransportRule(inf, ipv4CIDR, validOrder, ingressnodefwv1alpha1.ProtocolTypeTCP, validPort, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
+			configInterfaces(inf, []string{"eth0"})
 		})
 
 		It("restricts rule count", func() {
@@ -448,6 +458,7 @@ var _ = Describe("sourceCIDRs", func() {
 
 	BeforeEach(func() {
 		inf = getIngressNodeFirewall("sourcecidrs")
+		configInterfaces(inf, []string{"eth0"})
 	})
 
 	Context("and its IPV4", func() {
@@ -482,6 +493,7 @@ var _ = Describe("Pin holes", func() {
 
 	BeforeEach(func() {
 		inf = getIngressNodeFirewall("pinholes")
+		configInterfaces(inf, []string{"eth0"})
 	})
 
 	Context("will block", func() {
@@ -534,6 +546,7 @@ var _ = Describe("Pin holes", func() {
 	Context("will allow", func() {
 		It("rules which are close API server address", func() {
 			initCIDRTransportRule(inf, ipv4CIDR, 1, ingressnodefwv1alpha1.ProtocolTypeTCP, "6441-6442", ingressnodefwv1alpha1.IngressNodeFirewallDeny)
+			configInterfaces(inf, []string{"eth0"})
 			Expect(createIngressNodeFirewall(inf)).To(Succeed())
 			Expect(deleteIngressNodeFirewall(inf)).To(Succeed())
 		})


### PR DESCRIPTION

**- What this PR does and why is it needed**
follow up to #446 PR to update manifests and update unit-test
fixes #444 