### PR TITLE
Update ingress node firewall for 4.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Build the manager binary
 FROM golang:1.21 as builder
 
 WORKDIR /workspace

--- a/Dockerfile.daemon.openshift
+++ b/Dockerfile.daemon.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 
 WORKDIR /go/src/github.com/openshift/ingress-node-firewall
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.15.0
+VERSION ?= 4.16.0
 CSV_VERSION = $(shell echo $(VERSION) | sed 's/v//')
 ifeq ($(VERSION), latest)
 CSV_VERSION := 0.0.0

--- a/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
+++ b/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
     createdAt: "2022-10-28 00:00:00"
-    olm.skipRange: '>=4.11.0 <4.15.0'
+    olm.skipRange: '>=4.11.0 <4.16.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     operators.operatorframework.io/builder: operator-sdk-v1.25.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -96,7 +96,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: ingress-node-firewall.v4.15.0
+  name: ingress-node-firewall.v4.16.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -426,7 +426,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.15.0
+    olm-status-descriptors: ingress-node-firewall.v4.16.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall
@@ -436,7 +436,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  version: 4.15.0
+  version: 4.16.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
+++ b/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
     createdAt: "2022-10-28 00:00:00"
-    olm.skipRange: '>=4.11.0 <4.15.0'
+    olm.skipRange: '>=4.11.0 <4.16.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     repository: https://github.com/openshift/ingress-node-firewall
     support: Red Hat
@@ -63,7 +63,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.15.0
+    olm-status-descriptors: ingress-node-firewall.v4.16.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall

--- a/config/olm-install/install-resources.yaml
+++ b/config/olm-install/install-resources.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: ingress-node-firewall-system
 spec:
   displayName: Ingress Node Firewall Index
-  image: quay.io/openshift/ingress-nodefw/ingress-node-firewall-index:v4.15.0
+  image: quay.io/openshift/ingress-nodefw/ingress-node-firewall-index:v4.16.0
   publisher: github.com/openshift/ingress-node-firewall
   sourceType: grpc
 ---

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -6,8 +6,8 @@ updates:
       replace: "ingress-node-firewall.v{FULL_VER}"
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: "olm.skipRange: '>=4.15.0-0 <{MAJOR}.{MINOR}.0'"
-      replace: "olm.skipRange: '>=4.15.0-0 <{FULL_VER}'"
+    - search: "olm.skipRange: '>=4.16.0-0 <{MAJOR}.{MINOR}.0'"
+      replace: "olm.skipRange: '>=4.16.0-0 <{FULL_VER}'"
   - file: "ingress-node-firewall.package.yaml"
     update_list:
     - search: "currentCSV: ingress-node-firewall.v{MAJOR}.{MINOR}.0"

--- a/manifests/ingress-node-firewall.package.yaml
+++ b/manifests/ingress-node-firewall.package.yaml
@@ -1,4 +1,4 @@
 packageName: ingress-node-firewall
 channels:
 - name: "stable"
-  currentCSV: ingress-node-firewall.v4.15.0
+  currentCSV: ingress-node-firewall.v4.16.0

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
     createdAt: "2022-10-28 00:00:00"
-    olm.skipRange: '>=4.11.0 <4.15.0'
+    olm.skipRange: '>=4.11.0 <4.16.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     operators.operatorframework.io/builder: operator-sdk-v1.25.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -96,7 +96,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: ingress-node-firewall.v4.15.0
+  name: ingress-node-firewall.v4.16.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -426,7 +426,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.15.0
+    olm-status-descriptors: ingress-node-firewall.v4.16.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall
@@ -436,7 +436,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  version: 4.15.0
+  version: 4.16.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/openshift-ci/wait_for_csv.sh
+++ b/openshift-ci/wait_for_csv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=${VERSION:-"v4.15.0"}
+VERSION=${VERSION:-"v4.16.0"}
 CSV_NAME="ingress-node-firewall.${VERSION}"
 NAMESPACE=${NAMESPACE:-"openshift-ingress-node-firewall"}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,5 +3,5 @@ package version
 var (
 	// Version contains the version number. This will be replaced by the linker at build
 	// time.
-	Version = "4.15.0"
+	Version = "4.16.0"
 )


### PR DESCRIPTION
**- What this PR does and why is it needed**
update manifest/bundle and docker files to use 4.16
