### PR TITLE
OCPBUGS-31636: stable CSV: remove "replaces"

### DIFF
--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -444,7 +444,6 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  replaces: ingress-node-firewall.v4.15.0
   version: 4.16.0
   webhookdefinitions:
   - admissionReviewVersions:


### PR DESCRIPTION
iib cannot run when "replaces" specifies a version that's not in the index.
this prevents publishing in ART's internal early-operator index, and also prevents shipping.