### PR TITLE
Users prefer to have flexibility configuring SSH firewall rules

### DIFF
--- a/pkg/failsaferules/failsaferules.go
+++ b/pkg/failsaferules/failsaferules.go
@@ -21,10 +21,6 @@ var tcp = []TransportProtoFailSafeRule{
 		2379,
 	},
 	{
-		"SSH",
-		22,
-	},
-	{
 		"Kubelet",
 		10250,
 	},

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -536,11 +536,6 @@ var _ = Describe("Pin holes", func() {
 			initCIDRTransportRule(inf, ipv4CIDR, 1, ingressnodefwv1alpha1.ProtocolTypeTCP, "1-59999", ingressnodefwv1alpha1.IngressNodeFirewallDeny)
 			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
 		})
-
-		It("rule which conflict with SSH", func() {
-			initCIDRTransportRule(inf, ipv4CIDR, 1, ingressnodefwv1alpha1.ProtocolTypeTCP, "22", ingressnodefwv1alpha1.IngressNodeFirewallDeny)
-			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
-		})
 	})
 
 	Context("will allow", func() {


### PR DESCRIPTION
**- What this PR does and why is it needed**

Currently the SSH is protected by failsafe webhook preventing any attempts to configure any rules
for SSH this PR remove SSH from failsafe rules




**- How to verify it**
passed e2e and ut tests

**- Description for the changelog**
remove SSH from failsafe rules to give user flexibility to configure SSH rules