### PR TITLE
update ingress node firewall with 4.17 base images

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.21-openshift-4.17

--- a/Dockerfile.daemon.openshift
+++ b/Dockerfile.daemon.openshift
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
 
 WORKDIR /go/src/github.com/openshift/ingress-node-firewall
 COPY . .
 RUN ./hack/build-daemon.sh
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/ingress-node-firewall/bin/daemon /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/ingress-node-firewall/bin/syslog /usr/bin/
 CMD ["/usr/bin/daemon"]

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
 
 WORKDIR /workspace
 
@@ -18,7 +18,7 @@ COPY bindata/manifests/ bindata/manifests/
 # Build
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -mod=vendor -o manager main.go
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/bindata/manifests /bindata/manifests

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.16.0
+VERSION ?= 4.17.0
 CSV_VERSION = $(shell echo $(VERSION) | sed 's/v//')
 ifeq ($(VERSION), latest)
 CSV_VERSION := 0.0.0

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ingress-node-firewall
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
+++ b/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
@@ -85,7 +85,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
-    createdAt: "2024-04-20T12:38:04Z"
+    createdAt: "2024-05-22T10:36:46Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -93,7 +93,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.11.0 <4.16.0'
+    olm.skipRange: '>=4.11.0 <4.17.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -104,7 +104,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: ingress-node-firewall.v4.16.0
+  name: ingress-node-firewall.v4.17.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -434,7 +434,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.16.0
+    olm-status-descriptors: ingress-node-firewall.v4.17.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall
@@ -444,7 +444,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  version: 4.16.0
+  version: 4.17.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ingress-node-firewall
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
+++ b/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.11.0 <4.16.0'
+    olm.skipRange: '>=4.11.0 <4.17.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     repository: https://github.com/openshift/ingress-node-firewall
     support: Red Hat
@@ -71,7 +71,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.16.0
+    olm-status-descriptors: ingress-node-firewall.v4.17.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall

--- a/config/olm-install/install-resources.yaml
+++ b/config/olm-install/install-resources.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: ingress-node-firewall-system
 spec:
   displayName: Ingress Node Firewall Index
-  image: quay.io/openshift/ingress-nodefw/ingress-node-firewall-index:v4.16.0
+  image: quay.io/openshift/ingress-nodefw/ingress-node-firewall-index:v4.17.0
   publisher: github.com/openshift/ingress-node-firewall
   sourceType: grpc
 ---

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/ingress-node-firewall
 
-go 1.21.0
+go 1.21
 
-toolchain go1.22.2
+toolchain go1.21.7
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -6,8 +6,8 @@ updates:
       replace: "ingress-node-firewall.v{FULL_VER}"
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: "olm.skipRange: '>=4.16.0-0 <{MAJOR}.{MINOR}.0'"
-      replace: "olm.skipRange: '>=4.16.0-0 <{FULL_VER}'"
+    - search: "olm.skipRange: '>=4.17.0-0 <{MAJOR}.{MINOR}.0'"
+      replace: "olm.skipRange: '>=4.17.0-0 <{FULL_VER}'"
   - file: "ingress-node-firewall.package.yaml"
     update_list:
     - search: "currentCSV: ingress-node-firewall.v{MAJOR}.{MINOR}.0"

--- a/manifests/ingress-node-firewall.package.yaml
+++ b/manifests/ingress-node-firewall.package.yaml
@@ -1,4 +1,4 @@
 packageName: ingress-node-firewall
 channels:
 - name: "stable"
-  currentCSV: ingress-node-firewall.v4.16.0
+  currentCSV: ingress-node-firewall.v4.17.0

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -85,7 +85,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
-    createdAt: "2024-03-13T12:36:01Z"
+    createdAt: "2024-05-22T10:36:46Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -93,9 +93,9 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.11.0 <4.16.0'
+    olm.skipRange: '>=4.11.0 <4.17.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
-    operators.operatorframework.io/builder: operator-sdk-v1.33.0
+    operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/ingress-node-firewall
     support: Red Hat
@@ -104,7 +104,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: ingress-node-firewall.v4.16.0
+  name: ingress-node-firewall.v4.17.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -434,7 +434,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.16.0
+    olm-status-descriptors: ingress-node-firewall.v4.17.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall
@@ -444,7 +444,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  version: 4.16.0
+  version: 4.17.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/openshift-ci/ingress-node-firewall-operator-deploy/build_and_push_index.sh
+++ b/openshift-ci/ingress-node-firewall-operator-deploy/build_and_push_index.sh
@@ -6,9 +6,9 @@ cd /tmp/ingress-node-firewall-operator-deploy
 wget https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/linux-amd64-opm
 mv linux-amd64-opm opm
 chmod +x ./opm
-export pass=$( jq .\"image-registry.openshift-image-registry.svc:5000\".password /var/run/secrets/openshift.io/push/.dockercfg )
-podman login -u serviceaccount -p "${pass:1:-1}" image-registry.openshift-image-registry.svc:5000 --tls-verify=false
-
+pass=$( jq .\"image-registry.openshift-image-registry.svc:5000\".auth /var/run/secrets/openshift.io/push/.dockercfg )
+pass=`echo ${pass:1:-1} | base64 -d`
+podman login -u serviceaccount -p ${pass:8} image-registry.openshift-image-registry.svc:5000 --tls-verify=false
 podman build -f bundle.Dockerfile --tag image-registry.openshift-image-registry.svc:5000/openshift-marketplace/ingress-node-firewall-operator-bundle:latest .
 podman push image-registry.openshift-image-registry.svc:5000/openshift-marketplace/ingress-node-firewall-operator-bundle:latest --tls-verify=false
 

--- a/openshift-ci/wait_for_csv.sh
+++ b/openshift-ci/wait_for_csv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=${VERSION:-"v4.16.0"}
+VERSION=${VERSION:-"v4.17.0"}
 CSV_NAME="ingress-node-firewall.${VERSION}"
 NAMESPACE=${NAMESPACE:-"openshift-ingress-node-firewall"}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,5 +3,5 @@ package version
 var (
 	// Version contains the version number. This will be replaced by the linker at build
 	// time.
-	Version = "4.16.0"
+	Version = "4.17.0"
 )


### PR DESCRIPTION
**- What this PR does and why is it needed**
update ingress node firewall for OCP 4.17 release
update operator sdk

