### PR TITLE
fix go version to get successfull ART build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/ingress-node-firewall
 
 go 1.21.0
 
-toolchain go1.22.2
+toolchain go1.21.7
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible


### PR DESCRIPTION

**- What this PR does and why is it needed**
Image build with the following error
`Required/recommended Go toolchain version \'1.22.2\' is not supported yet.`
