### PR TITLE
Bump golang to go1.22

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/Dockerfile.daemon.openshift
+++ b/Dockerfile.daemon.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 
 WORKDIR /go/src/github.com/openshift/ingress-node-firewall
 COPY . .

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/ingress-node-firewall
 
-go 1.21
+go 1.22
 
-toolchain go1.21.7
+toolchain go1.22.3
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible


### PR DESCRIPTION
**- What this PR does and why is it needed**
bump golang to go1.22

this PR includes #525 & #524
