### PR TITLE
fix ci run errors

### DIFF
--- a/openshift-ci/deploy_ingress_node_firewall.sh
+++ b/openshift-ci/deploy_ingress_node_firewall.sh
@@ -79,7 +79,7 @@ do
 done
 
 oc cp ingress-node-firewall-operator-deploy openshift-marketplace/buildindex:/tmp
-oc exec -n openshift-marketplace buildindex /tmp/ingress-node-firewall-operator-deploy/build_and_push_index.sh
+oc exec -n openshift-marketplace buildindex -- /tmp/ingress-node-firewall-operator-deploy/build_and_push_index.sh
 
 oc apply -f ingress-node-firewall-operator-deploy/install-resources.yaml
 


### PR DESCRIPTION
error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead
