### PR TITLE
update INFW for OCP 4.19 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.daemon
+++ b/Dockerfile.daemon
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 WORKDIR /go/src/github.com/openshift/ingress-node-firewall
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.18.0
+VERSION ?= 4.19.0
 CSV_VERSION = $(shell echo $(VERSION) | sed 's/v//')
 ifeq ($(VERSION), latest)
 CSV_VERSION := 0.0.0

--- a/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
+++ b/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
@@ -87,7 +87,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
-    createdAt: "2024-09-13T12:46:10Z"
+    createdAt: "2024-12-04T21:37:24Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -95,7 +95,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.11.0 <4.18.0'
+    olm.skipRange: '>=4.11.0 <4.19.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -106,7 +106,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: ingress-node-firewall.v4.18.0
+  name: ingress-node-firewall.v4.19.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -448,7 +448,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.18.0
+    olm-status-descriptors: ingress-node-firewall.v4.19.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall
@@ -458,7 +458,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  version: 4.18.0
+  version: 4.19.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
+++ b/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.11.0 <4.18.0'
+    olm.skipRange: '>=4.11.0 <4.19.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     repository: https://github.com/openshift/ingress-node-firewall
     support: Red Hat
@@ -71,7 +71,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.18.0
+    olm-status-descriptors: ingress-node-firewall.v4.19.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall

--- a/config/olm-install/install-resources.yaml
+++ b/config/olm-install/install-resources.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: ingress-node-firewall-system
 spec:
   displayName: Ingress Node Firewall Index
-  image: quay.io/openshift/ingress-nodefw/ingress-node-firewall-index:v4.17.0
+  image: quay.io/openshift/ingress-nodefw/ingress-node-firewall-index:v4.19.0
   publisher: github.com/openshift/ingress-node-firewall
   sourceType: grpc
 ---

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -6,8 +6,8 @@ updates:
       replace: "ingress-node-firewall.v{FULL_VER}"
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: "olm.skipRange: '>=4.18.0-0 <{MAJOR}.{MINOR}.0'"
-      replace: "olm.skipRange: '>=4.18.0-0 <{FULL_VER}'"
+    - search: "olm.skipRange: '>=4.19.0-0 <{MAJOR}.{MINOR}.0'"
+      replace: "olm.skipRange: '>=4.19.0-0 <{FULL_VER}'"
   - file: "ingress-node-firewall.package.yaml"
     update_list:
     - search: "currentCSV: ingress-node-firewall.v{MAJOR}.{MINOR}.0"

--- a/manifests/ingress-node-firewall.package.yaml
+++ b/manifests/ingress-node-firewall.package.yaml
@@ -1,4 +1,4 @@
 packageName: ingress-node-firewall
 channels:
 - name: "stable"
-  currentCSV: ingress-node-firewall.v4.18.0
+  currentCSV: ingress-node-firewall.v4.19.0

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -87,7 +87,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
-    createdAt: "2024-09-13T12:46:10Z"
+    createdAt: "2024-12-04T21:37:24Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -95,7 +95,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.11.0 <4.18.0'
+    olm.skipRange: '>=4.11.0 <4.19.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -106,7 +106,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: ingress-node-firewall.v4.18.0
+  name: ingress-node-firewall.v4.19.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -448,7 +448,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.18.0
+    olm-status-descriptors: ingress-node-firewall.v4.19.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall
@@ -458,7 +458,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  version: 4.18.0
+  version: 4.19.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/openshift-ci/wait_for_csv.sh
+++ b/openshift-ci/wait_for_csv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=${VERSION:-"v4.18.0"}
+VERSION=${VERSION:-"v4.19.0"}
 CSV_NAME="ingress-node-firewall.${VERSION}"
 NAMESPACE=${NAMESPACE:-"openshift-ingress-node-firewall"}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,5 +3,5 @@ package version
 var (
 	// Version contains the version number. This will be replaced by the linker at build
 	// time.
-	Version = "4.18.0"
+	Version = "4.19.0"
 )


### PR DESCRIPTION

**- What this PR does and why is it needed**
Update ingress node firewall for OCP release 4.19
