### PR TITLE
OCPBUGS-59926: fix-ingress-node-firewall-e2e-metal-ipi

### DIFF
--- a/openshift-ci/ingress-node-firewall-operator-deploy/build_and_push_index.sh
+++ b/openshift-ci/ingress-node-firewall-operator-deploy/build_and_push_index.sh
@@ -6,8 +6,9 @@ cd /tmp/ingress-node-firewall-operator-deploy
 wget https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/linux-amd64-opm
 mv linux-amd64-opm opm
 chmod +x ./opm
-export pass=$( jq .\"image-registry.openshift-image-registry.svc:5000\".password /var/run/secrets/openshift.io/push/.dockercfg )
-podman login -u serviceaccount -p "${pass:1:-1}" image-registry.openshift-image-registry.svc:5000 --tls-verify=false
+pass=$( jq .\"image-registry.openshift-image-registry.svc:5000\".auth /var/run/secrets/openshift.io/push/.dockercfg )
+pass=`echo ${pass:1:-1} | base64 -d`
+podman login -u serviceaccount -p ${pass:8} image-registry.openshift-image-registry.svc:5000 --tls-verify=false
 
 podman build -f bundle.Dockerfile --tag image-registry.openshift-image-registry.svc:5000/openshift-marketplace/ingress-node-firewall-operator-bundle:latest .
 podman push image-registry.openshift-image-registry.svc:5000/openshift-marketplace/ingress-node-firewall-operator-bundle:latest --tls-verify=false


### PR DESCRIPTION
Fix a PROW job failure in 4.16 caused by misconfiguration in extracting the pull secret/password.

Tracker : https://issues.redhat.com/browse/OCPBUGS-59926