### PR TITLE
OCPBUGS-31495: sanitize pin filenames to enable pinning subinterfaces

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,19 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	PinDirDotPlaceholder = "__dot__"
+)

--- a/pkg/ebpf/ingress_node_firewall_loader_test.go
+++ b/pkg/ebpf/ingress_node_firewall_loader_test.go
@@ -128,3 +128,31 @@ func cleanup(t *testing.T) {
 		t.Log(err)
 	}
 }
+
+func TestSanitizePinDir(t *testing.T) {
+	tests := []struct {
+		in       string
+		expected string
+	}{
+		{
+			in:       "eth0",
+			expected: "eth0",
+		},
+		{
+			in:       "bond0.100",
+			expected: "bond0__dot__100",
+		},
+		{
+			in:       "eth0__dot__100",
+			expected: "eth0.100",
+		},
+	}
+
+	for _, tc := range tests {
+		result := sanitizePinDir(tc.in)
+		if result != tc.expected {
+			t.Fatalf("Failed to sanitize, expected %s, got %s",
+				tc.expected, result)
+		}
+	}
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	ingressnodefwv1alpha1 "github.com/openshift/ingress-node-firewall/api/v1alpha1"
+	"github.com/openshift/ingress-node-firewall/pkg/constants"
 	"github.com/openshift/ingress-node-firewall/pkg/failsaferules"
 	"github.com/openshift/ingress-node-firewall/pkg/utils"
 
@@ -103,6 +104,11 @@ func validateINFInterfaces(ctx context.Context, infInterfaces []string, infName 
 			allErrs = append(allErrs,
 				field.Invalid(field.NewPath("Spec").Child("interfaces").Index(index),
 					infName, fmt.Sprintf("interface %q can't start with a number", inf)))
+		}
+		if strings.Contains(inf, constants.PinDirDotPlaceholder) {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("Spec").Child("interfaces").Index(index),
+					infName, fmt.Sprintf("interface %q can't contain '%s'", inf, constants.PinDirDotPlaceholder)))
 		}
 	}
 	return allErrs

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+
 	//+kubebuilder:scaffold:imports
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -177,6 +178,17 @@ var _ = Describe("Interfaces", func() {
 		It("interfaces config with interface name starts with number", func() {
 			initCIDRICMPRule(inf, ipv4CIDR, validOrder, false, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
 			configInterfaces(inf, []string{"0th"})
+			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
+		})
+		It("interfaces config with interface name containing dot", func() {
+			initCIDRICMPRule(inf, ipv4CIDR, validOrder, false, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
+			configInterfaces(inf, []string{"eth0.100"})
+			Expect(createIngressNodeFirewall(inf)).To(Succeed())
+			Expect(deleteIngressNodeFirewall(inf)).To(Succeed())
+		})
+		It("interfaces config with interface name containing dot placeholder", func() {
+			initCIDRICMPRule(inf, ipv4CIDR, validOrder, false, icmpTypeEchoReply, icmpTypeEchoReply, ingressnodefwv1alpha1.IngressNodeFirewallAllow)
+			configInterfaces(inf, []string{"eth0__dot__100"})
 			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
 		})
 	})


### PR DESCRIPTION
The [BPF fs does not allow dots](https://github.com/torvalds/linux/blob/6146a0f1dfae5d37442a9ddcba012add260bceb0/kernel/bpf/inode.c#L371-L381
) (".") in filenames, which prevents subinterfaces to be pinned correctly. By translating these dots before writing to bpffs this allows pinning subinterfaces (e.g. vlans).


**- What this PR does and why is it needed**
Without the change, using a subinterface (with a dot in its generated pinDir filename), an error is logged:

```
$ oc logs -n openshift-ingress-node-firewall ingress-node-firewall-daemon-xxx -c daemon
2025-11-03T20:32:22Z    ERROR   controllers.IngressNodeFirewall Fail to attach ingress firewall prog    {"error": "failed to pin link to pinDir /sys/fs/bpf/xdp_ingress_node_firewall_process/vlan.100_link: operation not permitted", "errorCauses": [{"error": "failed to pin link to pinDir /sys/fs/bpf/xdp_ingress_node_firewall_process/vlan.100_link: operation not permitted"}]}    
```


**- How to verify it**
Create an `ingressnodefirewall` targeting a vlan interface:

```
$ oc debug node/<node-name> -- ls -l /host/sys/fs/bpf/xdp_ingress_node_firewall_process/
Starting pod/<node-name>-debug-xxx ...
To use host binaries, run `chroot /host`. Instead, if you need to access host namespaces, run `nsenter -a -t 1`.
total 0
-rw-------. 1 root root 0 Nov  3 20:39 ingress_node_firewall_dbg_map
-rw-------. 1 root root 0 Nov  3 20:39 ingress_node_firewall_events_map
-rw-------. 1 root root 0 Nov  3 20:39 ingress_node_firewall_statistics_map
-rw-------. 1 root root 0 Nov  3 20:39 ingress_node_firewall_table_map
-rw-------. 1 root root 0 Nov  3 20:39 vlan_dot_100_link
```

Delete the rule again and see the link being upinned:

```
$ oc delete ingressnodefirewall vlan100
ingressnodefirewall.ingressnodefirewall.openshift.io "vlan100" deleted
$ oc logs -n openshift-ingress-node-firewall ingress-node-firewall-daemon-xxx -c daemon
<...>
2025/11/03 20:41:37 Detaching IngressNode Firewall program from interface "vlan.100"
2025/11/03 20:41:37 Running Unpin and Close for link &{{0xc002cc8b38 /sys/fs/bpf/xdp_ingress_node_firewall_process/vlan_dot_100_link}}
```


**- Description for the changelog**
Allow subinterfaces to be pinned by converting filename dots with a placeholder for writing to the `BPF` filesystem.
