### PR TITLE
CNF-23398: Upgrade golangci-lint from v1.54.2 to v2.12.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+version: "2"
+run:
+  timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,7 @@ catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 CILIUM_EBPF_VERSION := v0.18.0
-GOLANGCI_LINT_VERSION = v1.54.2
+GOLANGCI_LINT_VERSION = v2.0.2
 CLANG ?= clang
 CFLAGS := -O2 -g -Wall -Werror $(CFLAGS)
 GOOS ?= linux
@@ -429,7 +429,7 @@ LOCAL_GENERATOR_IMAGE ?= ebpf-generator:latest
 ##@ eBPF development
 .PHONY: prereqs
 prereqs: ## Check if prerequisites are met, and installing missing dependencies
-	test -f $(shell go env GOPATH)/bin/golangci-lint || GOFLAGS="" go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+	test -f $(shell go env GOPATH)/bin/golangci-lint || GOFLAGS="" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 	test -f $(shell go env GOPATH)/bin/bpf2go || go install github.com/cilium/ebpf/cmd/bpf2go@${CILIUM_EBPF_VERSION}
 	test -f $(shell go env GOPATH)/bin/kind || go install sigs.k8s.io/kind@latest
 

--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,7 @@ catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 CILIUM_EBPF_VERSION := v0.18.0
-GOLANGCI_LINT_VERSION = v1.54.2
+GOLANGCI_LINT_VERSION = v2.12.2
 CLANG ?= clang
 CFLAGS := -O2 -g -Wall -Werror $(CFLAGS)
 GOOS ?= linux
@@ -428,7 +428,7 @@ LOCAL_GENERATOR_IMAGE ?= ebpf-generator:latest
 ##@ eBPF development
 .PHONY: prereqs
 prereqs: ## Check if prerequisites are met, and installing missing dependencies
-	test -f $(shell go env GOPATH)/bin/golangci-lint || GOFLAGS="" go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+	test -f $(shell go env GOPATH)/bin/golangci-lint || GOFLAGS="" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 	test -f $(shell go env GOPATH)/bin/bpf2go || go install github.com/cilium/ebpf/cmd/bpf2go@${CILIUM_EBPF_VERSION}
 	test -f $(shell go env GOPATH)/bin/kind || go install sigs.k8s.io/kind@latest
 


### PR DESCRIPTION
## Summary
- Bumped golangci-lint from v1.54.2 to v2.12.2
- Updated module install path to `github.com/golangci/golangci-lint/v2/`
- Added `.golangci.yml` with v2 `version: "2"` declaration and 5m timeout

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [openshift/zero-trust-workload-identity-manager#90](https://github.com/openshift/zero-trust-workload-identity-manager/pull/90) | [CNF-23399](https://redhat.atlassian.net/browse/CNF-23399): Upgrade golangci-lint from v1.59.1 to v2.12.2 | Open |
| [openshift-kni/commatrix#480](https://github.com/openshift-kni/commatrix/pull/480) | [CNF-23208](https://redhat.atlassian.net/browse/CNF-23208): Upgrade golangci-lint from v1.63.4 to v2.12.2 | Open |

## Jira
- [CNF-23398](https://issues.redhat.com/browse/CNF-23398) — Upgrade golangci-lint from v1.54.2 to v2.12.2 in ingress-node-firewall (Code Review)
- Epic: [CNF-23396](https://issues.redhat.com/browse/CNF-23396) — GolangCI-Lint v2 Upgrade (In Progress)

## Upstream References
- [golangci-lint v2 migration guide](https://golangci-lint.run/product/migration-guide/)

## Test Plan
- [ ] CI passes
- [ ] Lint checks pass with new v2 config
