### PR TITLE
OCPBUGS-76699: ebpf: consolidate packet event logs into single line

### DIFF
--- a/pkg/ebpf/ingress_node_firewall_events.go
+++ b/pkg/ebpf/ingress_node_firewall_events.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 	"unsafe"
@@ -104,66 +105,44 @@ func (infc *IngNodeFwController) ingressNodeFwEvents() error {
 				log.Printf("lookup network iface %d: %s", eventHdr.IfId, err)
 				continue
 			}
-			if err := eventsLogger.Info(fmt.Sprintf("ruleId %d action %s len %d if %s\n",
-				eventHdr.RuleId, convertXdpActionToString(eventHdr.Action), eventHdr.PktLength, iface.Name)); err != nil {
-				log.Printf("syslog event logging failed %q", err)
-			}
+			// Build a complete log message with all packet details
+			var logMsg strings.Builder
+			fmt.Fprintf(&logMsg, "ruleId %d action %s len %d if %s",
+				eventHdr.RuleId, convertXdpActionToString(eventHdr.Action), eventHdr.PktLength, iface.Name)
+
 			decodePacket := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
-			// check for IPv4
+
+			// Append IP layer information
 			if ip4Layer := decodePacket.Layer(layers.LayerTypeIPv4); ip4Layer != nil {
 				ip, _ := ip4Layer.(*layers.IPv4)
-				if err := eventsLogger.Info(fmt.Sprintf("\tipv4 src addr %s dst addr %s\n", ip.SrcIP.String(), ip.DstIP.String())); err != nil {
-					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
-						eventHdr.RuleId, iface.Name, err)
-				}
-			}
-			// check for IPv6
-			if ip6Layer := decodePacket.Layer(layers.LayerTypeIPv6); ip6Layer != nil {
+				fmt.Fprintf(&logMsg, " | ipv4 src %s dst %s", ip.SrcIP.String(), ip.DstIP.String())
+			} else if ip6Layer := decodePacket.Layer(layers.LayerTypeIPv6); ip6Layer != nil {
 				ip, _ := ip6Layer.(*layers.IPv6)
-				if err := eventsLogger.Info(fmt.Sprintf("\tipv6 src addr %s dst addr %s\n", ip.SrcIP.String(), ip.DstIP.String())); err != nil {
-					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
-						eventHdr.RuleId, iface.Name, err)
-				}
+				fmt.Fprintf(&logMsg, " | ipv6 src %s dst %s", ip.SrcIP.String(), ip.DstIP.String())
 			}
-			// check for TCP
+
+			// Append protocol-specific information
 			if tcpLayer := decodePacket.Layer(layers.LayerTypeTCP); tcpLayer != nil {
 				tcp, _ := tcpLayer.(*layers.TCP)
-				if err := eventsLogger.Info(fmt.Sprintf("\ttcp srcPort %d dstPort %d\n", tcp.SrcPort, tcp.DstPort)); err != nil {
-					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
-						eventHdr.RuleId, iface.Name, err)
-				}
-			}
-			// check for UDP
-			if udpLayer := decodePacket.Layer(layers.LayerTypeUDP); udpLayer != nil {
+				fmt.Fprintf(&logMsg, " | tcp srcPort %d dstPort %d", tcp.SrcPort, tcp.DstPort)
+			} else if udpLayer := decodePacket.Layer(layers.LayerTypeUDP); udpLayer != nil {
 				udp, _ := udpLayer.(*layers.UDP)
-				if err := eventsLogger.Info(fmt.Sprintf("\tudp srcPort %d dstPort %d\n", udp.SrcPort, udp.DstPort)); err != nil {
-					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
-						eventHdr.RuleId, iface.Name, err)
-				}
-			}
-			// check fo SCTP
-			if sctpLayer := decodePacket.Layer(layers.LayerTypeSCTP); sctpLayer != nil {
+				fmt.Fprintf(&logMsg, " | udp srcPort %d dstPort %d", udp.SrcPort, udp.DstPort)
+			} else if sctpLayer := decodePacket.Layer(layers.LayerTypeSCTP); sctpLayer != nil {
 				sctp, _ := sctpLayer.(*layers.SCTP)
-				if err := eventsLogger.Info(fmt.Sprintf("\tsctp srcPort %d dstPort %d\n", sctp.SrcPort, sctp.DstPort)); err != nil {
-					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
-						eventHdr.RuleId, iface.Name, err)
-				}
-			}
-			// check for ICMPv4
-			if icmpv4Layer := decodePacket.Layer(layers.LayerTypeICMPv4); icmpv4Layer != nil {
+				fmt.Fprintf(&logMsg, " | sctp srcPort %d dstPort %d", sctp.SrcPort, sctp.DstPort)
+			} else if icmpv4Layer := decodePacket.Layer(layers.LayerTypeICMPv4); icmpv4Layer != nil {
 				icmp, _ := icmpv4Layer.(*layers.ICMPv4)
-				if err := eventsLogger.Info(fmt.Sprintf("\ticmpv4 type %d code %d\n", icmp.TypeCode.Type(), icmp.TypeCode.Code())); err != nil {
-					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
-						eventHdr.RuleId, iface.Name, err)
-				}
-			}
-			// check for ICMPV6
-			if icmpv6Layer := decodePacket.Layer(layers.LayerTypeICMPv6); icmpv6Layer != nil {
+				fmt.Fprintf(&logMsg, " | icmpv4 type %d code %d", icmp.TypeCode.Type(), icmp.TypeCode.Code())
+			} else if icmpv6Layer := decodePacket.Layer(layers.LayerTypeICMPv6); icmpv6Layer != nil {
 				icmp, _ := icmpv6Layer.(*layers.ICMPv6)
-				if err := eventsLogger.Info(fmt.Sprintf("\ticmpv6 type %d code %d\n", icmp.TypeCode.Type(), icmp.TypeCode.Code())); err != nil {
-					log.Printf("syslog event logging for ruleId %d on intrerface %s failed err: %q",
-						eventHdr.RuleId, iface.Name, err)
-				}
+				fmt.Fprintf(&logMsg, " | icmpv6 type %d code %d", icmp.TypeCode.Type(), icmp.TypeCode.Code())
+			}
+
+			// Log the complete message as a single line
+			if err := eventsLogger.Info(logMsg.String()); err != nil {
+				log.Printf("syslog event logging for ruleId %d on interface %s failed err: %q",
+					eventHdr.RuleId, iface.Name, err)
 			}
 		}
 	}()

--- a/test/e2e/events/events.go
+++ b/test/e2e/events/events.go
@@ -62,7 +62,7 @@ func extractEventsFromString(str string) ([]TestEvent, error) {
 	// Transport regular expression
 	// Match for each drop.
 	// If any change to the event output in pkg/ebpf/ingress_node_firewall_events.go, an update is required here.
-	transportEventRE := "ruleId\\s([0-9]+)\\saction\\s(?P<action>\\w+).*if\\s(?P<inf>\\w+)\n.*\\ssrc\\saddr\\s(?P<srcaddr>[0-9.:a-z]+)\\sdst\\saddr\\s(?P<dstaddr>[0-9.:a-z]+)\n.*(?P<proto>tcp|udp|sctp)\\ssrcPort\\s\\d+\\sdstPort\\s(?P<dstport>\\d+)"
+	transportEventRE := `ruleId\s([0-9]+)\saction\s(?P<action>\w+).*if\s(?P<inf>\w+)\s\|\s(?:ipv4|ipv6)\ssrc\s(?P<srcaddr>[0-9.:a-z]+)\sdst\s(?P<dstaddr>[0-9.:a-z]+)\s\|\s(?P<proto>tcp|udp|sctp)\ssrcPort\s\d+\sdstPort\s(?P<dstport>\d+)`
 	transportEventPattern := regexp.MustCompile(transportEventRE)
 	for _, match := range transportEventPattern.FindAllStringSubmatch(str, -1) { // -1 for unlimited matches
 		var te TestEvent
@@ -94,7 +94,7 @@ func extractEventsFromString(str string) ([]TestEvent, error) {
 	// ICMP regular expression
 	// Match for each drop.
 	// If any change to the event output in pkg/ebpf/ingress_node_firewall_events.go, an update is required here.
-	icmpEventRE := "ruleId\\s([0-9]+)\\saction\\s(?P<action>\\w+).*if\\s(?P<inf>\\w+)\\n.*\\s(ipv4|ipv6)\\ssrc\\saddr\\s(?P<srcaddr>[0-9.:a-z]+)\\sdst\\saddr\\s(?P<dstaddr>[0-9.:a-z]+)\\n.*(?P<proto>icmpv4|icmpv6)\\stype\\s(?P<type>\\d+)\\scode\\s(?P<code>\\d+)"
+	icmpEventRE := `ruleId\s([0-9]+)\saction\s(?P<action>\w+).*if\s(?P<inf>\w+)\s\|\s(?:ipv4|ipv6)\ssrc\s(?P<srcaddr>[0-9.:a-z]+)\sdst\s(?P<dstaddr>[0-9.:a-z]+)\s\|\s(?P<proto>icmpv4|icmpv6)\stype\s(?P<type>\d+)\scode\s(?P<code>\d+)`
 	icmpEventPattern := regexp.MustCompile(icmpEventRE)
 	for _, match := range icmpEventPattern.FindAllStringSubmatch(str, -1) {
 		var te TestEvent


### PR DESCRIPTION
Previously, firewall packet events were logged as three separate syslog messages (rule info, IP addresses, protocol details), making log parsing and analysis more difficult. This change consolidates all packet event information into a single log line for better observability.

Changes:
- Merge three separate eventsLogger.Info() calls into one
- Use pipe separators (|) to delimit log sections visually
- Change independent if statements to if-else if chains to ensure only one IP layer and one protocol layer is logged per packet
- Simplify log format: "src addr"/"dst addr" -> "src"/"dst"

**Example output format:**
Before (3 lines):
```
  2026-02-06 09:04:59 +0000 UTC worker1.example.com ruleId 10 action Drop len 74 if br1
  2026-02-06 09:04:59 +0000 UTC worker1.example.com     ipv4 src addr 192.XX.XX.149 dst addr 192.XX.XX.56
  2026-02-06 09:04:59 +0000 UTC worker1.example.com     tcp srcPort 56354 dstPort 22
```

After (1 line):
`  2026-02-06 09:04:59 +0000 UTC ruleId 10 action Drop len 74 if br1 | ipv4 src 192.xx.xx.149 dst 192.xx.xx.56 | tcp srcPort 56354 dstPort 22`

This improves log grep-ability, parsing, and integration with log aggregation tools where single-line entries are preferred.

**Test result from ovnkind cluster after appling the fix**
```
$ kubectl logs -c events ingress-node-firewall-daemon-w756x
2026-04-02 08:58:19 +0000 UTC ovn-worker ruleId 10 action Drop len 74 if breth0 | ipv4 src 10.xx.0.1 dst 10.xx.0.16 | tcp srcPort 54600 dstPort 5000
2026-04-02 09:03:45 +0000 UTC ovn-worker ruleId 10 action Drop len 74 if breth0 | ipv4 src 10.xx.0.1 dst 10.xx.0.16 | tcp srcPort 37006 dstPort 5000
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated ingress firewall event logging so each packet event is emitted as a single, unified log message containing rule ID, action, packet length, interface, and protocol/transport details.
  * Improved error handling so failures for the consolidated log write are captured once with the full message.
  * Updated event parsing to match the new single-line, pipe-delimited log format for transport and ICMP events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->