### PR TITLE
OCPBUGS-79056: update INFW to 4.22 version

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.22
+  tag: rhel-9-release-golang-1.25-openshift-4.22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 as builder
+FROM golang:1.25 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.daemon
+++ b/Dockerfile.daemon
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 WORKDIR /go/src/github.com/openshift/ingress-node-firewall
 COPY . .
 

--- a/Dockerfile.daemon.openshift
+++ b/Dockerfile.daemon.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 
 WORKDIR /go/src/github.com/openshift/ingress-node-firewall
 COPY . .

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.21.0
+VERSION ?= 4.22.0
 CSV_VERSION = $(shell echo $(VERSION) | sed 's/v//')
 ifeq ($(VERSION), latest)
 CSV_VERSION := 0.0.0
@@ -57,7 +57,7 @@ endif
 IMG ?= quay.io/openshift/origin-ingress-node-firewall:latest
 DAEMON_IMG ?= quay.io/openshift/origin-ingress-node-firewall-daemon:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25.2
+ENVTEST_K8S_VERSION = 1.32.x
 
 # Default namespace
 NAMESPACE ?= ingress-node-firewall-system
@@ -126,11 +126,15 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS_DIR)/bin" go test ./... -coverprofile cover.out
+	@set -e; \
+	export KUBEBUILDER_ASSETS=$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir /tmp/envtest-binaries -p path); \
+	go test ./... -coverprofile cover.out
 
 .PHONY: test-race
 test-race: manifests generate fmt vet envtest ## Run tests and check for race conditions.
-	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS_DIR)/bin" go test -race ./...
+	@set -e; \
+	export KUBEBUILDER_ASSETS=$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir /tmp/envtest-binaries -p path); \
+	go test -race ./...
 
 .PHONY: create-kind-cluster 
 create-kind-cluster: ## Create a kind cluster.
@@ -264,7 +268,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+CONTROLLER_TOOLS_VERSION ?= v0.20.1
 OPERATOR_SDK_VERSION=v1.33.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
@@ -278,15 +282,10 @@ controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessar
 $(CONTROLLER_GEN): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) GOFLAGS="" go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN)
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR);
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) GOFLAGS="" go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
 
 .PHONY: bundle
 bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
@@ -356,7 +355,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.24.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ make undeploy-samples
 
 You need to install the following packages:
 
-operator-sdk 1.22.0
+operator-sdk 1.33.0
 
-controller-gen v0.9.0+
+controller-gen v0.20.1+
 
 For fedora, you will need the following packages
 ```sh

--- a/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
+++ b/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
@@ -95,7 +95,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.11.0 <4.21.0'
+    olm.skipRange: '>=4.11.0 <4.22.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -106,7 +106,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: ingress-node-firewall.v4.21.0
+  name: ingress-node-firewall.v4.22.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -448,7 +448,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.21.0
+    olm-status-descriptors: ingress-node-firewall.v4.22.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall
@@ -458,7 +458,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  version: 4.21.0
+  version: 4.22.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallconfigs.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: ingressnodefirewallconfigs.ingressnodefirewall.openshift.io
 spec:
   group: ingressnodefirewall.openshift.io
@@ -70,16 +70,8 @@ spec:
                 description: Conditions show the current state of the Ingress Node
                   Firewall Config resource
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -120,12 +112,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: ingressnodefirewallnodestates.ingressnodefirewall.openshift.io
 spec:
   group: ingressnodefirewall.openshift.io

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: ingressnodefirewalls.ingressnodefirewall.openshift.io
 spec:
   group: ingressnodefirewall.openshift.io

--- a/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
+++ b/config/manifests/bases/ingress-node-firewall.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.11.0 <4.21.0'
+    olm.skipRange: '>=4.11.0 <4.22.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     repository: https://github.com/openshift/ingress-node-firewall
     support: Red Hat
@@ -71,7 +71,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.21.0
+    olm-status-descriptors: ingress-node-firewall.v4.22.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall

--- a/config/olm-install/install-resources.yaml
+++ b/config/olm-install/install-resources.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: ingress-node-firewall-system
 spec:
   displayName: Ingress Node Firewall Index
-  image: quay.io/openshift/ingress-nodefw/ingress-node-firewall-index:v4.21.0
+  image: quay.io/openshift/ingress-nodefw/ingress-node-firewall-index:v4.22.0
   publisher: github.com/openshift/ingress-node-firewall
   sourceType: grpc
 ---

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,43 +40,7 @@ rules:
   - ingressnodefirewall.openshift.io
   resources:
   - ingressnodefirewallconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ingressnodefirewall.openshift.io
-  resources:
-  - ingressnodefirewallconfigs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ingressnodefirewall.openshift.io
-  resources:
-  - ingressnodefirewallconfigs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ingressnodefirewall.openshift.io
-  resources:
   - ingressnodefirewallnodestates
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ingressnodefirewall.openshift.io
-  resources:
   - ingressnodefirewalls
   verbs:
   - create
@@ -89,12 +53,14 @@ rules:
 - apiGroups:
   - ingressnodefirewall.openshift.io
   resources:
+  - ingressnodefirewallconfigs/finalizers
   - ingressnodefirewalls/finalizers
   verbs:
   - update
 - apiGroups:
   - ingressnodefirewall.openshift.io
   resources:
+  - ingressnodefirewallconfigs/status
   - ingressnodefirewalls/status
   verbs:
   - get

--- a/controllers/ingressnodefirewall_controller_rules_test.go
+++ b/controllers/ingressnodefirewall_controller_rules_test.go
@@ -313,7 +313,7 @@ var _ = Describe("IngressNodeFirewall controller rules", func() {
 									Order: 10,
 									ProtocolConfig: infv1alpha1.IngressNodeProtocolConfig{
 										Protocol: infv1alpha1.ProtocolTypeUDP,
-										TCP: &infv1alpha1.IngressNodeFirewallProtoRule{
+										UDP: &infv1alpha1.IngressNodeFirewallProtoRule{
 											Ports: intstr.FromInt(80),
 										},
 									},

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/ingress-node-firewall
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.0
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible

--- a/hack/generators.Dockerfile
+++ b/hack/generators.Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:40
 
-ARG GOVERSION="1.24.7"
+ARG GOVERSION="1.25.0"
 
 # Installs dependencies that are required to compile eBPF programs
 RUN dnf install -y git kernel-devel make llvm clang glibc-devel.i686 unzip clang-tools-extra

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -6,8 +6,8 @@ updates:
       replace: "ingress-node-firewall.v{FULL_VER}"
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: "olm.skipRange: '>=4.21.0-0 <{MAJOR}.{MINOR}.0'"
-      replace: "olm.skipRange: '>=4.21.0-0 <{FULL_VER}'"
+    - search: "olm.skipRange: '>=4.22.0-0 <{MAJOR}.{MINOR}.0'"
+      replace: "olm.skipRange: '>=4.22.0-0 <{FULL_VER}'"
   - file: "ingress-node-firewall.package.yaml"
     update_list:
     - search: "currentCSV: ingress-node-firewall.v{MAJOR}.{MINOR}.0"

--- a/manifests/ingress-node-firewall.package.yaml
+++ b/manifests/ingress-node-firewall.package.yaml
@@ -1,4 +1,4 @@
 packageName: ingress-node-firewall
 channels:
 - name: "stable"
-  currentCSV: ingress-node-firewall.v4.21.0
+  currentCSV: ingress-node-firewall.v4.22.0

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -87,7 +87,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
-    createdAt: "2024-12-04T21:37:24Z"
+    createdAt: "2025-09-04T08:08:17Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -95,7 +95,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.11.0 <4.21.0'
+    olm.skipRange: '>=4.11.0 <4.22.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -106,7 +106,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: ingress-node-firewall.v4.21.0
+  name: ingress-node-firewall.v4.22.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -448,7 +448,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.21.0
+    olm-status-descriptors: ingress-node-firewall.v4.22.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall
@@ -458,7 +458,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  version: 4.21.0
+  version: 4.22.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/openshift-ci/wait_for_csv.sh
+++ b/openshift-ci/wait_for_csv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=${VERSION:-"v4.21.0"}
+VERSION=${VERSION:-"v4.22.0"}
 CSV_NAME="ingress-node-firewall.${VERSION}"
 NAMESPACE=${NAMESPACE:-"openshift-ingress-node-firewall"}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,5 +3,5 @@ package version
 var (
 	// Version contains the version number. This will be replaced by the linker at build
 	// time.
-	Version = "4.21.0"
+	Version = "4.22.0"
 )


### PR DESCRIPTION
Upgrades INFW version to 4.22.

Copy/Replace of: https://github.com/openshift/ingress-node-firewall/pull/705


Bump Go version from 1.24.0 to 1.25.0 to satisfy controller-gen@v0.20.1
requirement (requires Go >= 1.25.0). Update go.mod and all Dockerfiles
to use Go 1.25 for consistency.

Fix test case that was using TCP field with UDP protocol type. The
updated controller-gen enforces stricter validation where protocol type
must match the field used in protocolConfig.

Update Makefile to use modern setup-envtest Go binary instead of
deprecated shell script that was failing with 403 errors from Google
Cloud Storage. Align versions with project dependencies:
- ENVTEST_K8S_VERSION: 1.25.2 → 1.32.x (matches k8s.io/* v0.32.3)
- CONTROLLER_TOOLS_VERSION: v0.14.0 → v0.20.1 (matches controller-runtime v0.20.4)
- setup-envtest pinned to v0.20.4 (matches controller-runtime v0.20.4)
- Add GOFLAGS="" to setup-envtest install to fix -mod=vendor CI errors

Regenerate CRDs and RBAC with updated controller-gen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bumped operator to v4.22.0 and updated packaged CSV/channel references and OLM skip ranges.

* **Chores**
  * Upgraded Go toolchain to 1.25 across builds and images.
  * Updated build tooling, envtest/Kubernetes test targets, and opm acquisition.
  * Updated catalog/install image tag to v4.22.0.
  * Consolidated RBAC rules for config finalizers/status permissions.

* **Bug Fixes**
  * Corrected UDP protocol handling in tests.

* **Docs**
  * Updated README tooling versions and shortened CRD description text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->