### PR TITLE
OCPBUGS-86869: Upgrades envtest Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 IMG ?= quay.io/openshift/origin-ingress-node-firewall:latest
 DAEMON_IMG ?= quay.io/openshift/origin-ingress-node-firewall-daemon:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25.2
+ENVTEST_K8S_VERSION = 1.32.x
 
 # Default namespace
 NAMESPACE ?= ingress-node-firewall-system
@@ -126,11 +126,15 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS_DIR)/bin" go test ./... -coverprofile cover.out
+	@set -e; \
+	export KUBEBUILDER_ASSETS=$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir /tmp/envtest-binaries -p path); \
+	go test ./... -coverprofile cover.out
 
 .PHONY: test-race
 test-race: manifests generate fmt vet envtest ## Run tests and check for race conditions.
-	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS_DIR)/bin" go test -race ./...
+	@set -e; \
+	export KUBEBUILDER_ASSETS=$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir /tmp/envtest-binaries -p path); \
+	go test -race ./...
 
 .PHONY: create-kind-cluster 
 create-kind-cluster: ## Create a kind cluster.
@@ -278,15 +282,10 @@ controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessar
 $(CONTROLLER_GEN): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) GOFLAGS="" go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN)
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR);
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) GOFLAGS="" go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
 
 .PHONY: bundle
 bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallconfigs.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: ingressnodefirewallconfigs.ingressnodefirewall.openshift.io
 spec:
   group: ingressnodefirewall.openshift.io
@@ -70,16 +70,8 @@ spec:
                 description: Conditions show the current state of the Ingress Node
                   Firewall Config resource
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -120,12 +112,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: ingressnodefirewallnodestates.ingressnodefirewall.openshift.io
 spec:
   group: ingressnodefirewall.openshift.io

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: ingressnodefirewalls.ingressnodefirewall.openshift.io
 spec:
   group: ingressnodefirewall.openshift.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,43 +40,7 @@ rules:
   - ingressnodefirewall.openshift.io
   resources:
   - ingressnodefirewallconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ingressnodefirewall.openshift.io
-  resources:
-  - ingressnodefirewallconfigs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ingressnodefirewall.openshift.io
-  resources:
-  - ingressnodefirewallconfigs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ingressnodefirewall.openshift.io
-  resources:
   - ingressnodefirewallnodestates
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ingressnodefirewall.openshift.io
-  resources:
   - ingressnodefirewalls
   verbs:
   - create
@@ -89,12 +53,14 @@ rules:
 - apiGroups:
   - ingressnodefirewall.openshift.io
   resources:
+  - ingressnodefirewallconfigs/finalizers
   - ingressnodefirewalls/finalizers
   verbs:
   - update
 - apiGroups:
   - ingressnodefirewall.openshift.io
   resources:
+  - ingressnodefirewallconfigs/status
   - ingressnodefirewalls/status
   verbs:
   - get

--- a/controllers/ingressnodefirewall_controller_rules_test.go
+++ b/controllers/ingressnodefirewall_controller_rules_test.go
@@ -313,7 +313,7 @@ var _ = Describe("IngressNodeFirewall controller rules", func() {
 									Order: 10,
 									ProtocolConfig: infv1alpha1.IngressNodeProtocolConfig{
 										Protocol: infv1alpha1.ProtocolTypeUDP,
-										TCP: &infv1alpha1.IngressNodeFirewallProtoRule{
+										UDP: &infv1alpha1.IngressNodeFirewallProtoRule{
 											Ports: intstr.FromInt(80),
 										},
 									},

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -87,7 +87,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ingress-node-firewall:latest
-    createdAt: "2024-12-04T21:37:24Z"
+    createdAt: "2025-09-04T08:08:17Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"


### PR DESCRIPTION
- Sets it to use go install with 0.20.0 envtest version (compatible with go 1.24, and k8s.io/kubernetes v1.32.3).
- Updates test Makefile targets to reflect changes in envtest
- Other changes come from `make test` call that automates the updates of base CRD yamls.
- Updates failed test case: changed from TCP to UDP protocol, as it appears the test was not being executed properly.
- Old kubebuilder envtest was deprecated - https://github.com/kubernetes-sigs/kubebuilder/discussions/4082
- Unblocks: https://github.com/openshift/ingress-node-firewall/pull/703

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/openshift/ingress-node-firewall/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
Clone and run a make test locally.
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
