### PR TITLE
OCPBUGS-86839: Fix node label matching in triggerReconciliation

### DIFF
--- a/controllers/ingressnodefirewall_controller.go
+++ b/controllers/ingressnodefirewall_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 
 	infv1alpha1 "github.com/openshift/ingress-node-firewall/api/v1alpha1"
@@ -30,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -233,7 +233,8 @@ func (r *IngressNodeFirewallReconciler) triggerReconciliation(ctx context.Contex
 	}
 
 	for _, fwobj := range ingressNodeFirewallList.Items {
-		if reflect.DeepEqual(fwobj.Spec.NodeSelector.MatchLabels, object.GetLabels()) {
+		selector := labels.SelectorFromSet(fwobj.Spec.NodeSelector.MatchLabels)
+		if selector.Matches(labels.Set(object.GetLabels())) {
 			nodeState := fwobj
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{


### PR DESCRIPTION
Fixes [OCPBUGS-86839](https://redhat.atlassian.net/browse/OCPBUGS-86839)

Replace reflect.DeepEqual with proper label selector matching.
This ensures the operator correctly creates IngressNodeFirewallNodeState
objects for nodes added after the operator starts.

The previous implementation used DeepEqual which required exact
label match. The new implementation uses labels.SelectorFromSet
which properly handles label selectors per Kubernetes semantics.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/openshift/ingress-node-firewall/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
When a new worker node is added to the cluster after the Ingress Node Firewall operator has started, the operator does NOT create an IngressNodeFirewallNodeState object for that node.
  
  Root Cause: The triggerReconciliation function was using reflect.DeepEqual to compare node labels against the IngressNodeFirewall's nodeSelector.MatchLabels. This method requires exact label equality, which doesn't match Kubernetes label selector semantics.
  
  The Fix: Replace reflect.DeepEqual with the proper labels.SelectorFromSet().Matches() approach. This ensures the operator correctly evaluates whether a node matches the IngressNodeFirewall selector when new nodes are added or existing nodes are labeled.

<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
  - The reflect package import has been removed as it's no longer needed.
  - The new implementation uses k8s.io/apimachinery/pkg/labels which is the standard Kubernetes approach for label selector matching.
  - This fix ensures nodes added dynamically (via auto-scaling, manual addition, or label changes) are properly picked up by the operator.
  - The change is in the triggerReconciliation function in controllers/ingressnodefirewall_controller.go.
  

<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
 1. Setup: Deploy an IngressNodeFirewall with a specific node selector:
    - Add a new worker node to the cluster (via MachineSet or manual addition)
    - Verify IngressNodeFirewallNodeState is automatically created for the new node
    
Created test image quay.io/smulje/ingress-node-firewall-operator:fix-node-matching with fix and verified that fix is working : 
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
Fix operator not creating IngressNodeFirewallNodeState for nodes added after startup.
The triggerReconciliation function now uses proper Kubernetes label selector matching
(labels.SelectorFromSet) instead of reflect.DeepEqual, ensuring nodes added dynamically 
or through label changes are correctly reconciled.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node selection matching for IngressNodeFirewall to properly use Kubernetes label selector semantics instead of exact equality comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->