### PR TITLE
OCPBUGS-99202: Prevent daemon panic on out-of-range rule order

### DIFF
--- a/api/v1alpha1/ingressnodefirewall_types.go
+++ b/api/v1alpha1/ingressnodefirewall_types.go
@@ -90,10 +90,11 @@ type IngressNodeProtocolConfig struct {
 // IngressNodeFirewallProtocolRule defines an ingress node firewall rule per protocol.
 type IngressNodeFirewallProtocolRule struct {
 	// order defines the order of execution of ingress firewall rules.
-	// The minimum order value is 1 and the values must be unique.
-	// + index 0 is used internally as catch all for unclassified packets matching the same sourceCIDR.
+	// The minimum order value is 1, the maximum is 99, and the values must be unique.
+	// Index 0 is used internally as catch all for unclassified packets matching the same sourceCIDR.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum:=1
+	// +kubebuilder:validation:Maximum:=99
 	Order uint32 `json:"order"`
 
 	// protocolConfig is a discriminated union of a protocol's specific configuration for TCP, UDP, SCTP, ICMP and ICMPv6.

--- a/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
+++ b/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
@@ -64,8 +64,10 @@ spec:
                             order:
                               description: |-
                                 order defines the order of execution of ingress firewall rules.
-                                The minimum order value is 1 and the values must be unique.
+                                The minimum order value is 1, the maximum is 99, and the values must be unique.
+                                Index 0 is used internally as catch all for unclassified packets matching the same sourceCIDR.
                               format: int32
+                              maximum: 99
                               minimum: 1
                               type: integer
                             protocolConfig:

--- a/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/bundle/manifests/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -73,8 +73,10 @@ spec:
                           order:
                             description: |-
                               order defines the order of execution of ingress firewall rules.
-                              The minimum order value is 1 and the values must be unique.
+                              The minimum order value is 1, the maximum is 99, and the values must be unique.
+                              Index 0 is used internally as catch all for unclassified packets matching the same sourceCIDR.
                             format: int32
+                            maximum: 99
                             minimum: 1
                             type: integer
                           protocolConfig:

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
@@ -64,8 +64,10 @@ spec:
                             order:
                               description: |-
                                 order defines the order of execution of ingress firewall rules.
-                                The minimum order value is 1 and the values must be unique.
+                                The minimum order value is 1, the maximum is 99, and the values must be unique.
+                                Index 0 is used internally as catch all for unclassified packets matching the same sourceCIDR.
                               format: int32
+                              maximum: 99
                               minimum: 1
                               type: integer
                             protocolConfig:

--- a/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/config/crd/bases/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -63,8 +63,10 @@ spec:
                           order:
                             description: |-
                               order defines the order of execution of ingress firewall rules.
-                              The minimum order value is 1 and the values must be unique.
+                              The minimum order value is 1, the maximum is 99, and the values must be unique.
+                              Index 0 is used internally as catch all for unclassified packets matching the same sourceCIDR.
                             format: int32
+                            maximum: 99
                             minimum: 1
                             type: integer
                           protocolConfig:

--- a/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
+++ b/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewallnodestates.yaml
@@ -64,8 +64,10 @@ spec:
                             order:
                               description: |-
                                 order defines the order of execution of ingress firewall rules.
-                                The minimum order value is 1 and the values must be unique.
+                                The minimum order value is 1, the maximum is 99, and the values must be unique.
+                                Index 0 is used internally as catch all for unclassified packets matching the same sourceCIDR.
                               format: int32
+                              maximum: 99
                               minimum: 1
                               type: integer
                             protocolConfig:

--- a/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
+++ b/manifests/stable/ingressnodefirewall.openshift.io_ingressnodefirewalls.yaml
@@ -73,8 +73,10 @@ spec:
                           order:
                             description: |-
                               order defines the order of execution of ingress firewall rules.
-                              The minimum order value is 1 and the values must be unique.
+                              The minimum order value is 1, the maximum is 99, and the values must be unique.
+                              Index 0 is used internally as catch all for unclassified packets matching the same sourceCIDR.
                             format: int32
+                            maximum: 99
                             minimum: 1
                             type: integer
                           protocolConfig:

--- a/pkg/ebpf/ingress_node_firewall_loader.go
+++ b/pkg/ebpf/ingress_node_firewall_loader.go
@@ -521,6 +521,13 @@ func (infc *IngNodeFwController) makeIngressFwRulesMap(
 	for _, rule := range ingFirewallConfig.FirewallProtocolRules {
 		rule := rule
 		idx := rule.Order
+		// Order is used as a raw index into the fixed-size eBPF rules array.
+		// Bound-check against the array length so a crafted IngressNodeFirewallNodeState
+		// (which has no admission webhook) cannot panic the daemon.
+		if idx == 0 || int(idx) >= len(rules.Rules) {
+			return keys, rules, fmt.Errorf("rule order %d out of range; must be between 1 and %d",
+				idx, len(rules.Rules)-1)
+		}
 		rules.Rules[idx].RuleId = rule.Order
 		switch rule.ProtocolConfig.Protocol {
 		case ingressnodefwiov1alpha1.ProtocolTypeTCP:

--- a/pkg/failsaferules/failsaferules.go
+++ b/pkg/failsaferules/failsaferules.go
@@ -1,6 +1,6 @@
 package failsaferules
 
-var MAX_INGRESS_RULES = 100
+const MAX_INGRESS_RULES = 100
 
 type TransportProtoFailSafeRule struct {
 	serviceName string

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -176,6 +176,14 @@ func validateRules(allErrs field.ErrorList, rules []ingressnodefwv1alpha1.Ingres
 }
 
 func validateRule(rule ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule, infRulesIndex, ruleIndex int, infName string) *field.Error {
+	// Order must stay within [1, MAX_INGRESS_RULES) to match the CRD Maximum and the
+	// fixed-size rules array used by the daemon (index 0 is reserved).
+	if rule.Order < 1 || rule.Order >= uint32(failsaferules.MAX_INGRESS_RULES) {
+		return field.Invalid(field.NewPath("spec").Child("ingress").Index(infRulesIndex).Key("rules").Index(ruleIndex).Child("order"),
+			infName, fmt.Sprintf("order %d is out of range; must be between 1 and %d",
+				rule.Order, failsaferules.MAX_INGRESS_RULES-1))
+	}
+
 	if rule.ProtocolConfig.Protocol == ingressnodefwv1alpha1.ProtocolTypeICMP || rule.ProtocolConfig.Protocol == ingressnodefwv1alpha1.ProtocolTypeICMP6 {
 		if isValid, reason := isValidICMPICMPV6Rule(rule); !isValid {
 			return field.Invalid(field.NewPath("spec").Child("ingress").Index(infRulesIndex).Key("rules").Index(ruleIndex),

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -420,6 +420,28 @@ var _ = Describe("Rules", func() {
 			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
 		})
 
+		It("rejects order equal to MAX_INGRESS_RULES", func() {
+			inf.Spec.Ingress[0].FirewallProtocolRules = []ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule{
+				getTCPRule(uint32(failsaferules.MAX_INGRESS_RULES), ingressnodefwv1alpha1.ProtocolTypeTCP, validPort, ingressnodefwv1alpha1.IngressNodeFirewallAllow),
+			}
+			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
+		})
+
+		It("rejects order greater than maximum", func() {
+			inf.Spec.Ingress[0].FirewallProtocolRules = []ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule{
+				getTCPRule(^uint32(0), ingressnodefwv1alpha1.ProtocolTypeTCP, validPort, ingressnodefwv1alpha1.IngressNodeFirewallAllow),
+			}
+			Expect(createIngressNodeFirewall(inf)).ToNot(Succeed())
+		})
+
+		It("accepts order equal to maximum", func() {
+			inf.Spec.Ingress[0].FirewallProtocolRules = []ingressnodefwv1alpha1.IngressNodeFirewallProtocolRule{
+				getTCPRule(uint32(failsaferules.MAX_INGRESS_RULES-1), ingressnodefwv1alpha1.ProtocolTypeTCP, validPort, ingressnodefwv1alpha1.IngressNodeFirewallAllow),
+			}
+			Expect(createIngressNodeFirewall(inf)).To(Succeed())
+			Expect(deleteIngressNodeFirewall(inf)).To(Succeed())
+		})
+
 		It("only unique order is allowed", func() {
 			// create inf which has sourceCIRDR X order one
 			Expect(createIngressNodeFirewall(inf)).To(Succeed())


### PR DESCRIPTION
## Summary
- Cap `IngressNodeFirewallProtocolRule.order` at 99 in the CRD schema (covers both `IngressNodeFirewall` and `IngressNodeFirewallNodeState`)
- Reject out-of-range `order` in the admission webhook
- Validate `order` in the daemon before using it as an eBPF rules-array index, so a crafted NodeState cannot panic every node's reconciler into CrashLoopBackOff

`order` is consumed as a raw index into a fixed `[100]BpfRuleTypeSt` array (index 0 reserved). Previously only `minimum: 1` was enforced, and the webhook only checked rule count / uniqueness — any `order >= 100` (up to `uint32` max) panicked the daemon cluster-wide.

## Test plan
- [x] `go test ./pkg/failsaferules/`
- [ ] Webhook suite: rejects `order == 100` and `order == ^uint32(0)`; accepts `order == 99`
- [x] Apply an `IngressNodeFirewall` with `order: 100` and confirm API/webhook rejection
- [x] Apply an `IngressNodeFirewallNodeState` with `order: 100` and confirm CRD rejection (`should be less than or equal to 99`)
- [x] Confirm `order: 99` is accepted and daemons attach XDP without panic

## Cluster verification (OCP 4.21)
Reproduced the panic on stock 4.21 (`index out of range [100] with length 100`), then verified the fix with custom images built from this branch:

- Operator: `quay.io/smulje/ingress-node-firewall-operator:order-oob-fix`
- Daemon: `quay.io/smulje/ingress-node-firewall-daemon:order-oob-fix`

Results with the custom images:
- `order: 100` / `order: 4294967295` rejected by webhook
`An error occurred
Error "Invalid value: 100: spec.ingress[0].rules[0].order in body should be less than or equal to 99" for field "spec.ingress[0].rules[0].order".`
- `order: 99` applied successfully (`Synchronized`), daemons remained Running
- Direct `IngressNodeFirewallNodeState` write with `order: 100` rejected by updated CRD schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject firewall rule orders outside the supported range of 1–99.
  * Prevented invalid rule orders from causing runtime indexing errors.

* **Documentation**
  * Clarified that rule orders must be unique and that order 0 is reserved for internal catch-all handling.
  * Updated CRD schemas with the maximum order validation.

* **Tests**
  * Added coverage for minimum, maximum, and out-of-range rule order values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->