### PR TITLE
OCPBUGS-98613:Update INFW to 5.0 version

### DIFF
--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -95,7 +95,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.11.0 <4.22.0'
+    olm.skipRange: '>=4.11.0 <5.0.0'
     operatorframework.io/suggested-namespace: openshift-ingress-node-firewall
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -106,7 +106,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: ingress-node-firewall.v4.22.0
+  name: ingress-node-firewall.v5.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -396,7 +396,7 @@ spec:
   - ingressnodefirewall
   labels:
     olm-owner-enterprise-app: ingress-node-firewall
-    olm-status-descriptors: ingress-node-firewall.v4.22.0
+    olm-status-descriptors: ingress-node-firewall.v5.0.0
   links:
   - name: Ingress Node Firewall
     url: https://github.com/openshift/ingress-node-firewall
@@ -406,7 +406,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc
-  version: 4.22.0
+  version: 5.0.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1


### PR DESCRIPTION
FIXES : [OCPBUGS-98613](https://redhat.atlassian.net/browse/OCPBUGS-98613) : Ingress node operator 5.0 image installs version 4.22

Ingress Node Firewall Operator changed from 4.22.0 to 5.0.0
 
 Signed-off-by: mandakul@redhat.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the operator release metadata to version 5.0.0.
  * Expanded the supported upgrade path to include earlier 4.x releases through version 5.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->