### PR TITLE
Fix/envtest setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 IMG ?= quay.io/openshift/origin-ingress-node-firewall:latest
 DAEMON_IMG ?= quay.io/openshift/origin-ingress-node-firewall-daemon:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25.2
+ENVTEST_K8S_VERSION = 1.25.0
 
 # Default namespace
 NAMESPACE ?= ingress-node-firewall-system
@@ -70,7 +70,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
+# This is a requirement for 'setup-envtest' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
@@ -126,11 +126,11 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS_DIR)/bin" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) -p path)" go test ./... -coverprofile cover.out
 
 .PHONY: test-race
 test-race: manifests generate fmt vet envtest ## Run tests and check for race conditions.
-	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS_DIR)/bin" go test -race ./...
+	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) -p path)" go test -race ./...
 
 .PHONY: create-kind-cluster 
 create-kind-cluster: ## Create a kind cluster.
@@ -283,10 +283,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN)
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR);
+	GOBIN=$(LOCALBIN) GOFLAGS="" go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20241019152504-013f46fbca88
 
 .PHONY: bundle
 bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.

--- a/controllers/ingressnodefirewall_controller_rules_test.go
+++ b/controllers/ingressnodefirewall_controller_rules_test.go
@@ -313,7 +313,7 @@ var _ = Describe("IngressNodeFirewall controller rules", func() {
 									Order: 10,
 									ProtocolConfig: infv1alpha1.IngressNodeProtocolConfig{
 										Protocol: infv1alpha1.ProtocolTypeUDP,
-										TCP: &infv1alpha1.IngressNodeFirewallProtoRule{
+										UDP: &infv1alpha1.IngressNodeFirewallProtoRule{
 											Ports: intstr.FromInt(80),
 										},
 									},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/openshift/ingress-node-firewall/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

Migrates the envtest test infrastructure setup from the deprecated setup-envtest.sh shell script (controller-runtime v0.8.3) to the officially supported setup-envtest Go binary from [sigs.k8s.io/controller-runtime/tools/setup-envtest](http://sigs.k8s.io/controller-runtime/tools/setup-envtest).

The old script downloads kubebuilder binary tarballs from Google Cloud Storage URLs that no longer serve valid gzip archives, causing all unit tests to fail with:gzip: stdin: not in gzip format
tar: Error is not recoverable: exiting now




Additionally, the old script hardcoded K8s version 1.19.2 and ignored the ENVTEST_K8S_VERSION Makefile variable entirely.

This PR also fixes a pre-existing test bug in the "merging rules for the same interface, CIDR, order - different different protocol" test case, where the test fixture specified Protocol: UDP but populated the TCP config field instead of UDP. This bug was hidden because the old envtest setup was broken and tests were never actually executed. The same fix was already applied on release-4.19 via PR #762 (cherry-pick of #728).

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**

- Replace the envtest Makefile target with go install setup-envtest@v0.0.0-20241019152504-013f46fbca88 (Go 1.22-compatible submodule pseudo-version)
- Update test and test-race targets to use $$($(ENVTEST) use ...) for proper shell-time evaluation of KUBEBUILDER_ASSETS
- Change ENVTEST_K8S_VERSION from 1.25.2 to 1.25.0 (v1.25.2 does not exist in the envtest binary archive; v1.25.0 is the available 1.25.x release)
- Update stale comment referencing setup-envtest.sh
- Fix TCP: → UDP: in test fixture (controllers/ingressnodefirewall_controller_rules_test.go, line 316)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved test environment setup by automatically selecting the configured Kubernetes assets.
  - Simplified installation of the test environment tooling.
  - Updated an internal logging dependency to a newer patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->