### PR TITLE
OCPBUGS-111895: Add missing RBAC permissions for networking.k8s.io/ne…

### DIFF
--- a/bindata/manifests/daemon/networkpolicy.yaml
+++ b/bindata/manifests/daemon/networkpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-node-firewall-daemon
+  namespace: '{{.NameSpace}}'
+spec:
+  podSelector:
+    matchLabels:
+      app: ingress-node-firewall-daemon
+  policyTypes:
+  - Ingress
+  - Egress
+  # Deny all ingress traffic
+  ingress: []
+  # Allow all egress traffic
+  egress:
+  - {}
+

--- a/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
+++ b/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
@@ -381,6 +381,18 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: ingress-node-firewall-controller-manager
     strategy: deployment
   installModes:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,18 +13,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -131,3 +119,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/ingressnodefirewallconfig_controller.go
+++ b/controllers/ingressnodefirewallconfig_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
@@ -65,11 +66,11 @@ type IngressNodeFirewallConfigReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=apps,namespace=ingress-node-firewall-system,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.k8s.io,namespace=ingress-node-firewall-system,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 
 //+kubebuilder:rbac:groups=ingressnodefirewall.openshift.io,resources=ingressnodefirewallconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ingressnodefirewall.openshift.io,resources=ingressnodefirewallconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=ingressnodefirewall.openshift.io,resources=ingressnodefirewallconfigs/finalizers,verbs=update
-// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -135,6 +136,7 @@ func (r *IngressNodeFirewallConfigReconciler) SetupWithManager(mgr ctrl.Manager)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ingressnodefwv1alpha1.IngressNodeFirewallConfig{}).
 		Owns(&appsv1.DaemonSet{}).
+		Owns(&networkingv1.NetworkPolicy{}).
 		Complete(r)
 }
 
@@ -264,6 +266,14 @@ func (r *IngressNodeFirewallConfigReconciler) syncIngressNodeFwConfigResources(c
 				return err
 			}
 
+			if err := apply.ApplyObject(ctx, r.Client, obj); err != nil {
+				return errors.Wrapf(err, "could not apply (%s) %s", obj.GroupVersionKind(), obj.GetName())
+			}
+		} else if obj.GetKind() == "NetworkPolicy" {
+			// Handle NetworkPolicy
+			if err := ctrl.SetControllerReference(config, obj, r.Scheme); err != nil {
+				return errors.Wrapf(err, "Failed to set controller reference to %s %s", obj.GetNamespace(), obj.GetName())
+			}
 			if err := apply.ApplyObject(ctx, r.Client, obj); err != nil {
 				return errors.Wrapf(err, "could not apply (%s) %s", obj.GroupVersionKind(), obj.GetName())
 			}

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -381,6 +381,18 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: ingress-node-firewall-controller-manager
     strategy: deployment
   installModes:


### PR DESCRIPTION
The ingress-node-firewall-operator CSV was missing required RBAC permissions for networking.k8s.io/networkpolicies, causing the operator bundle to fail the Conforma policy check 'olm.required_network_policy_rbac_for_operands'.

This fix adds the required permissions by:
- Adding kubebuilder RBAC marker to ingressnodefirewall_controller.go
- Regenerating RBAC manifests with 'make manifests'
- Updating all CSV files in bundle/ and manifests/stable/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default network policy for the ingress node firewall daemon.
  * The policy blocks incoming traffic while allowing outgoing traffic.
  * The operator now manages network policies throughout their lifecycle.
* **Bug Fixes**
  * Improved deployment handling to ensure rendered daemon resources are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->