### PR TITLE
OCPBUGS-105459: KUBE_RBAC_PROXY_IMAGE is removed, and extraneous instances exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,6 @@ oc adm policy add-scc-to-user privileged -z ingress-node-firewall-daemon
 ```sh
 export DAEMONSET_IMAGE=<registry>/<image>:<tag>
 export DAEMONSET_NAMESPACE=ingress-node-firewall-system
-export KUBE_RBAC_PROXY_IMAGE=quay.io/openshift/origin-kube-rbac-proxy:latest
 make install run
 ```
 

--- a/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
+++ b/bundle/manifests/ingress-node-firewall.clusterserviceversion.yaml
@@ -259,8 +259,6 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                - name: KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:latest
                 image: quay.io/openshift/origin-ingress-node-firewall:latest
                 livenessProbe:
                   httpGet:

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -15,5 +15,3 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: KUBE_RBAC_PROXY_IMAGE
-              value: "quay.io/openshift/origin-kube-rbac-proxy:latest"

--- a/controllers/ingressnodefirewallconfig_controller.go
+++ b/controllers/ingressnodefirewallconfig_controller.go
@@ -147,7 +147,6 @@ func (r *IngressNodeFirewallConfigReconciler) syncIngressNodeFwConfigResources(c
 
 	data.Data["Image"] = os.Getenv("DAEMONSET_IMAGE")
 	data.Data["NameSpace"] = r.Namespace
-	data.Data["RBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["IsOpenShift"] = r.PlatformInfo.IsOpenShift()
 	if config.Spec.Debug != nil {
 		data.Data["Debug"] = "0"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -70,7 +70,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	By("Setting Ingress nodefirewall config environment variables")
 	Expect(os.Setenv("DAEMONSET_IMAGE", "test-daemon:latest")).To(Succeed())
-	Expect(os.Setenv("KUBE_RBAC_PROXY_IMAGE", "kube-rbac-proxy:latest")).To(Succeed())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/main.go
+++ b/main.go
@@ -118,10 +118,6 @@ func main() {
 		setupLog.Error(nil, "DAEMONSET_NAMESPACE env variable must be set")
 		os.Exit(1)
 	}
-	if _, ok = os.LookupEnv("KUBE_RBAC_PROXY_IMAGE"); !ok {
-		setupLog.Error(nil, "KUBE_RBAC_PROXY_IMAGE env variable must be set")
-		os.Exit(1)
-	}
 
 	tlsOpts := append(tlsProfile.TLSOpts, func(c *tls.Config) {
 		if enableHTTP2 {

--- a/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
+++ b/manifests/stable/ingress-node-firewall.clusterserviceversion.yaml
@@ -259,8 +259,6 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                - name: KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:latest
                 image: quay.io/openshift/origin-ingress-node-firewall:latest
                 livenessProbe:
                   httpGet:


### PR DESCRIPTION
OCPBUGS-105459: KUBE_RBAC_PROXY_IMAGE is removed, and extraneous instances exist

fixes: OCPBUGS-105459

**- What this PR does and why is it needed**

```
3m14s       Normal    Pulling               pod/ingress-node-firewall-daemon-9qfq9                            Pulling image "http://quay.io/openshift/origin-kube-rbac-proxy:latest "
3m8s        Normal    Pulled                pod/ingress-node-firewall-daemon-9qfq9                            Successfully pulled image "http://quay.io/openshift/origin-kube-rbac-proxy:latest " in 5.647s (5.647s including waiting). Image size: 436864195 bytes.
```

is implicitly used by the ClusterServiceVersion

See https://github.com/openshift/ingress-node-firewall/commit/100a5a2c413eb956eb6d86f8a448041d37a65a89 where it removes the KUBE_RBAC_PROXY

**- Special notes for reviewers**

This resolves 105459.

**- How to verify it**

Install on ARM or Power or s390x. 

**- Description for the changelog**

Resolve multi-arch support for non-x86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unnecessary RBAC proxy image configuration requirement from controller deployment settings.
  * Simplified installation and startup by eliminating validation for the unused environment variable.

* **Documentation**
  * Updated local operator-running instructions to reflect the streamlined configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->